### PR TITLE
fix: Disable Talos default CNI to prevent Cilium agent crashes

### DIFF
--- a/internal/platform/talos/config.go
+++ b/internal/platform/talos/config.go
@@ -251,7 +251,15 @@ func applyPatches(configBytes []byte, isControlPlane bool, hostname string) ([]b
 		cmExtraArgs["cloud-provider"] = "external"
 	}
 
-	// 2. Hostname
+	// 2. Disable default CNI (Flannel) to allow Cilium
+	// Talos includes Flannel as the default CNI, which conflicts with Cilium.
+	// Setting cni.name = "none" instructs Talos to not install any CNI,
+	// allowing Cilium to be deployed as the sole CNI provider.
+	clusterNetwork := getOrCreate(cluster, "network")
+	cni := getOrCreate(clusterNetwork, "cni")
+	cni["name"] = "none"
+
+	// 3. Hostname
 	if hostname != "" {
 		network := getOrCreate(machine, "network")
 		network["hostname"] = hostname


### PR DESCRIPTION
## Summary
- Fixes Cilium agent startup failures by disabling Talos's default Flannel CNI
- Adds `cluster.network.cni.name = "none"` patch to Talos machine config generation

## Problem
Talos Linux includes Flannel as its default CNI. When Cilium is deployed without disabling Flannel:
- Both CNI plugins run simultaneously, causing conflicts
- Cilium agents crash and enter BackOff restart loop
- `node.cilium.io/agent-not-ready` taint persists on all nodes
- All pods requiring CNI fail to schedule
- Errors: `dial unix /var/run/cilium/cilium.sock: connect: connection refused`

## Root Cause
The Terraform implementation correctly sets `cni = { name = "none" }` in `talos_config.tf`, but the Go implementation in `applyPatches()` was missing this critical configuration.

## Solution
Add the CNI disabling patch to `internal/platform/talos/config.go:applyPatches()`:
```go
clusterNetwork := getOrCreate(cluster, "network")
cni := getOrCreate(clusterNetwork, "cni")
cni["name"] = "none"
```

## Test plan
- [x] Unit tests pass
- [ ] E2E test validates Cilium agents start successfully
- [ ] Verify no `node.cilium.io/agent-not-ready` taint on nodes
- [ ] Verify pods can schedule and get networking

🤖 Generated with [Claude Code](https://claude.com/claude-code)