### PR TITLE
test: improve unit test coverage for cmd, config, and addons packages

### DIFF
--- a/cmd/k8zner/commands/apply_test.go
+++ b/cmd/k8zner/commands/apply_test.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	cmd := Apply()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "apply", cmd.Use)
+	assert.Equal(t, "Apply configuration to the cluster", cmd.Short)
+}
+
+func TestApply_ConfigFlag(t *testing.T) {
+	cmd := Apply()
+
+	flag := cmd.Flags().Lookup("config")
+	require.NotNil(t, flag, "config flag should exist")
+	assert.Equal(t, "c", flag.Shorthand)
+	assert.Equal(t, "", flag.DefValue)
+	assert.Equal(t, "Path to configuration file", flag.Usage)
+}
+
+func TestApply_ConfigFlagRequired(t *testing.T) {
+	cmd := Apply()
+
+	// The flag should be marked as required
+	flag := cmd.Flags().Lookup("config")
+	require.NotNil(t, flag)
+
+	// Check that the flag has the required annotation
+	annotations := flag.Annotations
+	_, hasRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.True(t, hasRequired || flag.Value.String() == "", "config flag should be required")
+}
+
+func TestApply_RunE(t *testing.T) {
+	cmd := Apply()
+	assert.NotNil(t, cmd.RunE, "Apply command should have RunE function")
+}

--- a/cmd/k8zner/commands/completion_test.go
+++ b/cmd/k8zner/commands/completion_test.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletion(t *testing.T) {
+	cmd := Completion()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "completion [bash|zsh|fish|powershell]", cmd.Use)
+	assert.Equal(t, "Generate shell completion scripts", cmd.Short)
+	assert.Contains(t, cmd.Long, "Generate shell completion scripts")
+}
+
+func TestCompletion_ValidArgs(t *testing.T) {
+	cmd := Completion()
+
+	expectedArgs := []string{"bash", "zsh", "fish", "powershell"}
+	assert.Equal(t, expectedArgs, cmd.ValidArgs)
+}
+
+func TestCompletion_DisableFlagsInUseLine(t *testing.T) {
+	cmd := Completion()
+	assert.True(t, cmd.DisableFlagsInUseLine)
+}
+
+func TestCompletion_ExactArgs(t *testing.T) {
+	cmd := Completion()
+
+	// Test that exactly 1 argument is required
+	assert.NotNil(t, cmd.Args)
+}
+
+func TestCompletion_RunE(t *testing.T) {
+	cmd := Completion()
+	assert.NotNil(t, cmd.RunE, "Completion command should have RunE function")
+}
+
+// Note: Completion commands write directly to os.Stdout (not cmd.OutOrStdout()),
+// so we just verify they execute without error.
+
+func TestCompletion_BashOutput(t *testing.T) {
+	root := Root()
+	root.SetArgs([]string{"completion", "bash"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+}
+
+func TestCompletion_ZshOutput(t *testing.T) {
+	root := Root()
+	root.SetArgs([]string{"completion", "zsh"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+}
+
+func TestCompletion_FishOutput(t *testing.T) {
+	root := Root()
+	root.SetArgs([]string{"completion", "fish"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+}
+
+func TestCompletion_PowershellOutput(t *testing.T) {
+	root := Root()
+	root.SetArgs([]string{"completion", "powershell"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+}
+
+func TestCompletion_InvalidShell(t *testing.T) {
+	root := Root()
+	root.SetArgs([]string{"completion", "invalid"})
+
+	err := root.Execute()
+	assert.Error(t, err)
+}
+
+func TestCompletion_NoArgs(t *testing.T) {
+	root := Root()
+	root.SetArgs([]string{"completion"})
+
+	err := root.Execute()
+	assert.Error(t, err)
+}

--- a/cmd/k8zner/commands/destroy_test.go
+++ b/cmd/k8zner/commands/destroy_test.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDestroy(t *testing.T) {
+	cmd := Destroy()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "destroy", cmd.Use)
+	assert.Equal(t, "Destroy a Kubernetes cluster and all associated resources", cmd.Short)
+	assert.Contains(t, cmd.Long, "Destroy removes all cluster resources")
+}
+
+func TestDestroy_ConfigFlag(t *testing.T) {
+	cmd := Destroy()
+
+	flag := cmd.Flags().Lookup("config")
+	require.NotNil(t, flag, "config flag should exist")
+	assert.Equal(t, "c", flag.Shorthand)
+	assert.Equal(t, "", flag.DefValue)
+	assert.Equal(t, "Path to cluster configuration file (required)", flag.Usage)
+}
+
+func TestDestroy_ConfigFlagRequired(t *testing.T) {
+	cmd := Destroy()
+
+	flag := cmd.Flags().Lookup("config")
+	require.NotNil(t, flag)
+
+	// Check that the flag has the required annotation
+	annotations := flag.Annotations
+	_, hasRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.True(t, hasRequired || flag.Value.String() == "", "config flag should be required")
+}
+
+func TestDestroy_RunE(t *testing.T) {
+	cmd := Destroy()
+	assert.NotNil(t, cmd.RunE, "Destroy command should have RunE function")
+}
+
+func TestDestroy_LongDescription(t *testing.T) {
+	cmd := Destroy()
+
+	// Verify the long description mentions key resources
+	assert.Contains(t, cmd.Long, "Servers")
+	assert.Contains(t, cmd.Long, "Load balancers")
+	assert.Contains(t, cmd.Long, "Networks")
+	assert.Contains(t, cmd.Long, "WARNING")
+}

--- a/cmd/k8zner/commands/image_test.go
+++ b/cmd/k8zner/commands/image_test.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImage(t *testing.T) {
+	cmd := Image()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "image", cmd.Use)
+	assert.Equal(t, "Manage Talos images", cmd.Short)
+}
+
+func TestImage_HasBuildSubcommand(t *testing.T) {
+	cmd := Image()
+
+	subcommands := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subcommands[sub.Use] = true
+	}
+
+	assert.True(t, subcommands["build"], "Expected build subcommand")
+}
+
+func TestBuild(t *testing.T) {
+	cmd := Build()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "build", cmd.Use)
+	assert.Equal(t, "Build a new Talos image", cmd.Short)
+}
+
+func TestBuild_NameFlag(t *testing.T) {
+	cmd := Build()
+
+	flag := cmd.Flags().Lookup("name")
+	require.NotNil(t, flag, "name flag should exist")
+	assert.Equal(t, "", flag.Shorthand)
+	assert.Equal(t, "talos", flag.DefValue)
+	assert.Equal(t, "Name of the image to create", flag.Usage)
+}
+
+func TestBuild_VersionFlag(t *testing.T) {
+	cmd := Build()
+
+	flag := cmd.Flags().Lookup("version")
+	require.NotNil(t, flag, "version flag should exist")
+	assert.Equal(t, "", flag.Shorthand)
+	assert.Equal(t, "v1.7.0", flag.DefValue)
+	assert.Equal(t, "Talos version to install", flag.Usage)
+}
+
+func TestBuild_LocationFlag(t *testing.T) {
+	cmd := Build()
+
+	flag := cmd.Flags().Lookup("location")
+	require.NotNil(t, flag, "location flag should exist")
+	assert.Equal(t, "", flag.Shorthand)
+	assert.Equal(t, "nbg1", flag.DefValue)
+	assert.Contains(t, flag.Usage, "Hetzner datacenter location")
+}
+
+func TestBuild_ArchFlag(t *testing.T) {
+	cmd := Build()
+
+	flag := cmd.Flags().Lookup("arch")
+	require.NotNil(t, flag, "arch flag should exist")
+	assert.Equal(t, "", flag.Shorthand)
+	assert.Equal(t, "amd64", flag.DefValue)
+	assert.Contains(t, flag.Usage, "Architecture")
+}
+
+func TestBuild_RunE(t *testing.T) {
+	cmd := Build()
+	assert.NotNil(t, cmd.RunE, "Build command should have RunE function")
+}

--- a/cmd/k8zner/commands/init_test.go
+++ b/cmd/k8zner/commands/init_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	cmd := Init()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "init", cmd.Use)
+	assert.Equal(t, "Interactively create a cluster configuration", cmd.Short)
+	assert.Contains(t, cmd.Long, "Interactively create a cluster configuration file")
+}
+
+func TestInit_OutputFlag(t *testing.T) {
+	cmd := Init()
+
+	flag := cmd.Flags().Lookup("output")
+	require.NotNil(t, flag, "output flag should exist")
+	assert.Equal(t, "o", flag.Shorthand)
+	assert.Equal(t, "cluster.yaml", flag.DefValue)
+	assert.Equal(t, "Output file path", flag.Usage)
+}
+
+func TestInit_AdvancedFlag(t *testing.T) {
+	cmd := Init()
+
+	flag := cmd.Flags().Lookup("advanced")
+	require.NotNil(t, flag, "advanced flag should exist")
+	assert.Equal(t, "a", flag.Shorthand)
+	assert.Equal(t, "false", flag.DefValue)
+	assert.Equal(t, "Show advanced configuration options", flag.Usage)
+}
+
+func TestInit_FullFlag(t *testing.T) {
+	cmd := Init()
+
+	flag := cmd.Flags().Lookup("full")
+	require.NotNil(t, flag, "full flag should exist")
+	assert.Equal(t, "f", flag.Shorthand)
+	assert.Equal(t, "false", flag.DefValue)
+	assert.Equal(t, "Output full YAML with all options", flag.Usage)
+}
+
+func TestInit_RunE(t *testing.T) {
+	cmd := Init()
+	assert.NotNil(t, cmd.RunE, "Init command should have RunE function")
+}

--- a/cmd/k8zner/commands/root_test.go
+++ b/cmd/k8zner/commands/root_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoot(t *testing.T) {
+	cmd := Root()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "k8zner", cmd.Use)
+	assert.Equal(t, "Provision Kubernetes on Hetzner Cloud using Talos", cmd.Short)
+}
+
+func TestRoot_HasSubcommands(t *testing.T) {
+	cmd := Root()
+
+	expectedSubcommands := []string{
+		"init",
+		"apply",
+		"image",
+		"destroy",
+		"upgrade",
+		"version",
+		"completion",
+	}
+
+	// Get subcommand names (first word of Use string)
+	subcommands := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		// Use string might include args like "completion [bash|zsh|fish|powershell]"
+		// So we extract just the command name
+		name := sub.Name()
+		subcommands[name] = true
+	}
+
+	for _, expected := range expectedSubcommands {
+		assert.True(t, subcommands[expected], "Expected subcommand %s not found", expected)
+	}
+}
+
+func TestRoot_SubcommandCount(t *testing.T) {
+	cmd := Root()
+	assert.Len(t, cmd.Commands(), 7, "Expected 7 subcommands")
+}

--- a/cmd/k8zner/commands/upgrade_test.go
+++ b/cmd/k8zner/commands/upgrade_test.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgrade(t *testing.T) {
+	cmd := Upgrade()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "upgrade", cmd.Use)
+	assert.Equal(t, "Upgrade Talos OS and Kubernetes versions", cmd.Short)
+	assert.Contains(t, cmd.Long, "Upgrade an existing cluster")
+}
+
+func TestUpgrade_ConfigFlag(t *testing.T) {
+	cmd := Upgrade()
+
+	flag := cmd.Flags().Lookup("config")
+	require.NotNil(t, flag, "config flag should exist")
+	assert.Equal(t, "c", flag.Shorthand)
+	assert.Equal(t, "", flag.DefValue)
+	assert.Equal(t, "Path to configuration file", flag.Usage)
+}
+
+func TestUpgrade_DryRunFlag(t *testing.T) {
+	cmd := Upgrade()
+
+	flag := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, flag, "dry-run flag should exist")
+	assert.Equal(t, "", flag.Shorthand)
+	assert.Equal(t, "false", flag.DefValue)
+	assert.Equal(t, "Show what would be upgraded without executing", flag.Usage)
+}
+
+func TestUpgrade_SkipHealthCheckFlag(t *testing.T) {
+	cmd := Upgrade()
+
+	flag := cmd.Flags().Lookup("skip-health-check")
+	require.NotNil(t, flag, "skip-health-check flag should exist")
+	assert.Equal(t, "", flag.Shorthand)
+	assert.Equal(t, "false", flag.DefValue)
+	assert.Equal(t, "Skip health checks between upgrades (dangerous)", flag.Usage)
+}
+
+func TestUpgrade_K8sVersionFlag(t *testing.T) {
+	cmd := Upgrade()
+
+	flag := cmd.Flags().Lookup("k8s-version")
+	require.NotNil(t, flag, "k8s-version flag should exist")
+	assert.Equal(t, "", flag.Shorthand)
+	assert.Equal(t, "", flag.DefValue)
+	assert.Equal(t, "Override Kubernetes version from config", flag.Usage)
+}
+
+func TestUpgrade_ConfigFlagRequired(t *testing.T) {
+	cmd := Upgrade()
+
+	flag := cmd.Flags().Lookup("config")
+	require.NotNil(t, flag)
+
+	// Check that the flag has the required annotation
+	annotations := flag.Annotations
+	_, hasRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.True(t, hasRequired || flag.Value.String() == "", "config flag should be required")
+}
+
+func TestUpgrade_RunE(t *testing.T) {
+	cmd := Upgrade()
+	assert.NotNil(t, cmd.RunE, "Upgrade command should have RunE function")
+}

--- a/cmd/k8zner/commands/version_test.go
+++ b/cmd/k8zner/commands/version_test.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion(t *testing.T) {
+	cmd := Version()
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "version", cmd.Use)
+	assert.Equal(t, "Print version information", cmd.Short)
+}
+
+func TestVersion_Run(t *testing.T) {
+	cmd := Version()
+	assert.NotNil(t, cmd.Run, "Version command should have Run function")
+}
+
+func TestSetVersionInfo(t *testing.T) {
+	// Save original values
+	origVersion := version
+	origCommit := commit
+	origDate := date
+
+	// Restore after test
+	defer func() {
+		version = origVersion
+		commit = origCommit
+		date = origDate
+	}()
+
+	// Set new values
+	SetVersionInfo("1.2.3", "abc123", "2024-01-01")
+
+	assert.Equal(t, "1.2.3", version)
+	assert.Equal(t, "abc123", commit)
+	assert.Equal(t, "2024-01-01", date)
+}
+
+func TestVersion_Output(t *testing.T) {
+	// Save original values
+	origVersion := version
+	origCommit := commit
+	origDate := date
+
+	// Restore after test
+	defer func() {
+		version = origVersion
+		commit = origCommit
+		date = origDate
+	}()
+
+	// Set test values
+	SetVersionInfo("test-version", "test-commit", "test-date")
+
+	// Verify the version values are set correctly
+	assert.Equal(t, "test-version", version)
+	assert.Equal(t, "test-commit", commit)
+	assert.Equal(t, "test-date", date)
+
+	// The version command uses fmt.Printf which writes to stdout,
+	// not to the command's output buffer. We just verify the command executes without error.
+	cmd := Version()
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestVersion_DefaultValues(t *testing.T) {
+	// Test that default values are set
+	cmd := Version()
+
+	// Just verify the command exists and has default values
+	assert.NotEmpty(t, cmd.Use)
+}

--- a/cmd/k8zner/handlers/upgrade_test.go
+++ b/cmd/k8zner/handlers/upgrade_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeOptions(t *testing.T) {
+	opts := UpgradeOptions{
+		ConfigPath:      "/path/to/config.yaml",
+		DryRun:          true,
+		SkipHealthCheck: true,
+		K8sVersion:      "v1.31.0",
+	}
+
+	assert.Equal(t, "/path/to/config.yaml", opts.ConfigPath)
+	assert.True(t, opts.DryRun)
+	assert.True(t, opts.SkipHealthCheck)
+	assert.Equal(t, "v1.31.0", opts.K8sVersion)
+}
+
+func TestUpgradeOptions_DefaultValues(t *testing.T) {
+	opts := UpgradeOptions{}
+
+	assert.Empty(t, opts.ConfigPath)
+	assert.False(t, opts.DryRun)
+	assert.False(t, opts.SkipHealthCheck)
+	assert.Empty(t, opts.K8sVersion)
+}
+
+func TestUpgrade_InvalidConfigPath(t *testing.T) {
+	opts := UpgradeOptions{
+		ConfigPath: "/nonexistent/path/config.yaml",
+	}
+
+	err := Upgrade(t.Context(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+func TestUpgrade_InvalidYAMLConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "invalid.yaml")
+
+	// Write invalid YAML
+	err := os.WriteFile(configPath, []byte("invalid: yaml: content: ["), 0600)
+	require.NoError(t, err)
+
+	opts := UpgradeOptions{
+		ConfigPath: configPath,
+	}
+
+	err = Upgrade(t.Context(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+func TestUpgrade_InvalidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Write config that will fail validation (missing required fields)
+	configContent := `
+cluster_name: ""
+location: ""
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0600)
+	require.NoError(t, err)
+
+	opts := UpgradeOptions{
+		ConfigPath: configPath,
+	}
+
+	err = Upgrade(t.Context(), opts)
+	require.Error(t, err)
+	// Either fails on validation or config load
+	assert.True(t,
+		contains(err.Error(), "invalid configuration") ||
+			contains(err.Error(), "failed to load config"),
+	)
+}
+
+func TestUpgrade_MissingSecretsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Write a minimal valid config
+	configContent := `
+cluster_name: test-cluster
+hcloud_token: test-token
+location: nbg1
+network:
+  ipv4_cidr: "10.0.0.0/16"
+control_plane:
+  nodepools:
+    - name: control-plane
+      type: cx21
+      count: 1
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0600)
+	require.NoError(t, err)
+
+	opts := UpgradeOptions{
+		ConfigPath: configPath,
+	}
+
+	// This will fail because secrets file doesn't exist
+	err = Upgrade(t.Context(), opts)
+	require.Error(t, err)
+	// Should fail on either secrets or validation
+	assert.True(t,
+		contains(err.Error(), "secrets") ||
+			contains(err.Error(), "invalid configuration") ||
+			contains(err.Error(), "failed to load"),
+	)
+}
+
+func TestUpgrade_K8sVersionOverride(t *testing.T) {
+	// This test verifies the opts structure supports version override
+	opts := UpgradeOptions{
+		ConfigPath: "/path/to/config.yaml",
+		K8sVersion: "v1.32.0",
+	}
+
+	assert.Equal(t, "v1.32.0", opts.K8sVersion)
+}
+
+// contains is a helper function for error checking
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr, 0))
+}
+
+func containsAt(s, substr string, start int) bool {
+	for i := start; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/addons/cert_manager_cloudflare_test.go
+++ b/internal/addons/cert_manager_cloudflare_test.go
@@ -1,0 +1,157 @@
+package addons
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestBuildClusterIssuerManifest_Staging(t *testing.T) {
+	email := "test@example.com"
+
+	manifest, err := buildClusterIssuerManifest(email, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest)
+
+	// Parse the YAML
+	var issuer map[string]any
+	err = yaml.Unmarshal(manifest, &issuer)
+	require.NoError(t, err)
+
+	// Check metadata
+	assert.Equal(t, "cert-manager.io/v1", issuer["apiVersion"])
+	assert.Equal(t, "ClusterIssuer", issuer["kind"])
+
+	metadata := issuer["metadata"].(map[string]any)
+	assert.Equal(t, "letsencrypt-cloudflare-staging", metadata["name"])
+
+	// Check spec
+	spec := issuer["spec"].(map[string]any)
+	acme := spec["acme"].(map[string]any)
+	assert.Equal(t, email, acme["email"])
+	assert.Equal(t, "https://acme-staging-v02.api.letsencrypt.org/directory", acme["server"])
+
+	// Check private key ref
+	privateKeyRef := acme["privateKeySecretRef"].(map[string]any)
+	assert.Equal(t, "letsencrypt-cloudflare-staging-key", privateKeyRef["name"])
+
+	// Check solvers
+	solvers := acme["solvers"].([]any)
+	require.Len(t, solvers, 1)
+
+	solver := solvers[0].(map[string]any)
+	dns01 := solver["dns01"].(map[string]any)
+	cloudflare := dns01["cloudflare"].(map[string]any)
+
+	apiTokenRef := cloudflare["apiTokenSecretRef"].(map[string]any)
+	assert.Equal(t, cloudflareSecretName, apiTokenRef["name"])
+	assert.Equal(t, "api-token", apiTokenRef["key"])
+}
+
+func TestBuildClusterIssuerManifest_Production(t *testing.T) {
+	email := "admin@example.org"
+
+	manifest, err := buildClusterIssuerManifest(email, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, manifest)
+
+	// Parse the YAML
+	var issuer map[string]any
+	err = yaml.Unmarshal(manifest, &issuer)
+	require.NoError(t, err)
+
+	// Check metadata
+	metadata := issuer["metadata"].(map[string]any)
+	assert.Equal(t, "letsencrypt-cloudflare-production", metadata["name"])
+
+	// Check spec
+	spec := issuer["spec"].(map[string]any)
+	acme := spec["acme"].(map[string]any)
+	assert.Equal(t, email, acme["email"])
+	assert.Equal(t, "https://acme-v02.api.letsencrypt.org/directory", acme["server"])
+
+	// Check private key ref
+	privateKeyRef := acme["privateKeySecretRef"].(map[string]any)
+	assert.Equal(t, "letsencrypt-cloudflare-production-key", privateKeyRef["name"])
+}
+
+func TestBuildClusterIssuerManifest_DifferentEmails(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+	}{
+		{"simple email", "test@example.com"},
+		{"with subdomain", "admin@mail.example.com"},
+		{"with plus", "test+cert@example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := buildClusterIssuerManifest(tt.email, false)
+			require.NoError(t, err)
+
+			var issuer map[string]any
+			err = yaml.Unmarshal(manifest, &issuer)
+			require.NoError(t, err)
+
+			spec := issuer["spec"].(map[string]any)
+			acme := spec["acme"].(map[string]any)
+			assert.Equal(t, tt.email, acme["email"])
+		})
+	}
+}
+
+func TestBuildClusterIssuerManifest_ValidYAML(t *testing.T) {
+	manifest, err := buildClusterIssuerManifest("test@example.com", false)
+	require.NoError(t, err)
+
+	// Verify it's valid YAML by unmarshaling
+	var parsed any
+	err = yaml.Unmarshal(manifest, &parsed)
+	assert.NoError(t, err, "Generated manifest should be valid YAML")
+}
+
+func TestBuildClusterIssuerManifest_BothEnvironments(t *testing.T) {
+	email := "test@example.com"
+
+	stagingManifest, err := buildClusterIssuerManifest(email, false)
+	require.NoError(t, err)
+
+	productionManifest, err := buildClusterIssuerManifest(email, true)
+	require.NoError(t, err)
+
+	// Verify they are different
+	assert.NotEqual(t, string(stagingManifest), string(productionManifest))
+
+	// Verify staging contains staging URLs
+	assert.Contains(t, string(stagingManifest), "staging")
+	assert.Contains(t, string(stagingManifest), "letsencrypt-cloudflare-staging")
+
+	// Verify production contains production URLs
+	assert.Contains(t, string(productionManifest), "production")
+	assert.Contains(t, string(productionManifest), "letsencrypt-cloudflare-production")
+	assert.NotContains(t, string(productionManifest), "staging")
+}
+
+func TestClusterIssuerData_Fields(t *testing.T) {
+	// Test the structure directly
+	data := clusterIssuerData{
+		Name:           "test-issuer",
+		Email:          "test@example.com",
+		Server:         "https://acme.example.com",
+		PrivateKeyName: "test-key",
+		SecretName:     "test-secret",
+		SecretKey:      "api-token",
+		Production:     true,
+	}
+
+	assert.Equal(t, "test-issuer", data.Name)
+	assert.Equal(t, "test@example.com", data.Email)
+	assert.Equal(t, "https://acme.example.com", data.Server)
+	assert.Equal(t, "test-key", data.PrivateKeyName)
+	assert.Equal(t, "test-secret", data.SecretName)
+	assert.Equal(t, "api-token", data.SecretKey)
+	assert.True(t, data.Production)
+}

--- a/internal/addons/cloudflare_secret_test.go
+++ b/internal/addons/cloudflare_secret_test.go
@@ -1,0 +1,129 @@
+package addons
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Note: Uses mockK8sClient from kubectl_test.go (same package)
+
+func TestCreateCloudflareSecret(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		apiToken    string
+		mockErr     error
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:      "success external-dns namespace",
+			namespace: "external-dns",
+			apiToken:  "cf-api-token-123",
+			mockErr:   nil,
+			expectErr: false,
+		},
+		{
+			name:      "success cert-manager namespace",
+			namespace: "cert-manager",
+			apiToken:  "cf-api-token-456",
+			mockErr:   nil,
+			expectErr: false,
+		},
+		{
+			name:        "client error",
+			namespace:   "external-dns",
+			apiToken:    "cf-api-token",
+			mockErr:     errors.New("create failed"),
+			expectErr:   true,
+			errContains: "failed to create cloudflare secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := new(mockK8sClient)
+
+			var capturedSecret *corev1.Secret
+			client.On("CreateSecret", mock.Anything, mock.AnythingOfType("*v1.Secret")).Run(func(args mock.Arguments) {
+				capturedSecret = args.Get(1).(*corev1.Secret)
+			}).Return(tt.mockErr)
+
+			err := createCloudflareSecret(context.Background(), client, tt.namespace, tt.apiToken)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+
+				// Verify secret structure
+				require.NotNil(t, capturedSecret)
+				assert.Equal(t, cloudflareSecretName, capturedSecret.Name)
+				assert.Equal(t, tt.namespace, capturedSecret.Namespace)
+				assert.Equal(t, corev1.SecretTypeOpaque, capturedSecret.Type)
+				assert.Equal(t, tt.apiToken, capturedSecret.StringData["api-token"])
+			}
+
+			client.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCreateExternalDNSNamespace(t *testing.T) {
+	namespaceYAML := createExternalDNSNamespace()
+
+	assert.Contains(t, namespaceYAML, "apiVersion: v1")
+	assert.Contains(t, namespaceYAML, "kind: Namespace")
+	assert.Contains(t, namespaceYAML, "name: external-dns")
+}
+
+func TestCreateCloudflareSecret_SecretNameConstant(t *testing.T) {
+	// Verify the constant is set correctly
+	assert.Equal(t, "cloudflare-api-token", cloudflareSecretName)
+}
+
+func TestCreateCloudflareSecret_SecretKeyName(t *testing.T) {
+	client := new(mockK8sClient)
+
+	var capturedSecret *corev1.Secret
+	client.On("CreateSecret", mock.Anything, mock.AnythingOfType("*v1.Secret")).Run(func(args mock.Arguments) {
+		capturedSecret = args.Get(1).(*corev1.Secret)
+	}).Return(nil)
+
+	err := createCloudflareSecret(context.Background(), client, "test-ns", "test-token")
+	require.NoError(t, err)
+
+	// Verify the key name is "api-token"
+	_, exists := capturedSecret.StringData["api-token"]
+	assert.True(t, exists, "Secret should have 'api-token' key")
+
+	// Verify no other keys
+	assert.Len(t, capturedSecret.StringData, 1)
+}
+
+func TestCloudflareSecretName_UsedInCertManagerCloudflare(t *testing.T) {
+	// Verify the constant is used in ClusterIssuer manifest
+	manifest, err := buildClusterIssuerManifest("test@example.com", false)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(manifest), cloudflareSecretName)
+}
+
+func TestCloudflareSecretName_UsedInExternalDNSValues(t *testing.T) {
+	// Verify the constant is used in external-dns values
+	// This is implicitly tested via the env var reference
+	cfg := &struct {
+		Name string
+	}{
+		Name: cloudflareSecretName,
+	}
+
+	assert.Equal(t, "cloudflare-api-token", cfg.Name)
+}

--- a/internal/addons/external_dns_test.go
+++ b/internal/addons/external_dns_test.go
@@ -1,0 +1,275 @@
+package addons
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/imamik/k8zner/internal/addons/helm"
+	"github.com/imamik/k8zner/internal/config"
+)
+
+func TestBuildExternalDNSValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *config.Config
+		expectedOwner  string
+		expectedPolicy string
+		checkExtraArgs func(t *testing.T, extraArgs []string)
+	}{
+		{
+			name: "default values with cluster name as owner ID",
+			config: &config.Config{
+				ClusterName: "my-cluster",
+				Addons: config.AddonsConfig{
+					ExternalDNS: config.ExternalDNSConfig{
+						Enabled: true,
+					},
+					Cloudflare: config.CloudflareConfig{
+						Domain: "example.com",
+					},
+				},
+			},
+			expectedOwner:  "my-cluster",
+			expectedPolicy: "sync",
+			checkExtraArgs: func(t *testing.T, extraArgs []string) {
+				assert.Empty(t, extraArgs, "No extra args without proxied or zone ID")
+			},
+		},
+		{
+			name: "custom owner ID",
+			config: &config.Config{
+				ClusterName: "my-cluster",
+				Addons: config.AddonsConfig{
+					ExternalDNS: config.ExternalDNSConfig{
+						Enabled:    true,
+						TXTOwnerID: "custom-owner",
+					},
+					Cloudflare: config.CloudflareConfig{
+						Domain: "example.com",
+					},
+				},
+			},
+			expectedOwner:  "custom-owner",
+			expectedPolicy: "sync",
+		},
+		{
+			name: "upsert-only policy",
+			config: &config.Config{
+				ClusterName: "my-cluster",
+				Addons: config.AddonsConfig{
+					ExternalDNS: config.ExternalDNSConfig{
+						Enabled: true,
+						Policy:  "upsert-only",
+					},
+					Cloudflare: config.CloudflareConfig{
+						Domain: "example.com",
+					},
+				},
+			},
+			expectedOwner:  "my-cluster",
+			expectedPolicy: "upsert-only",
+		},
+		{
+			name: "cloudflare proxied enabled",
+			config: &config.Config{
+				ClusterName: "my-cluster",
+				Addons: config.AddonsConfig{
+					ExternalDNS: config.ExternalDNSConfig{
+						Enabled: true,
+					},
+					Cloudflare: config.CloudflareConfig{
+						Domain:  "example.com",
+						Proxied: true,
+					},
+				},
+			},
+			expectedOwner:  "my-cluster",
+			expectedPolicy: "sync",
+			checkExtraArgs: func(t *testing.T, extraArgs []string) {
+				assert.Contains(t, extraArgs, "--cloudflare-proxied")
+			},
+		},
+		{
+			name: "cloudflare zone ID specified",
+			config: &config.Config{
+				ClusterName: "my-cluster",
+				Addons: config.AddonsConfig{
+					ExternalDNS: config.ExternalDNSConfig{
+						Enabled: true,
+					},
+					Cloudflare: config.CloudflareConfig{
+						Domain: "example.com",
+						ZoneID: "abc123",
+					},
+				},
+			},
+			expectedOwner:  "my-cluster",
+			expectedPolicy: "sync",
+			checkExtraArgs: func(t *testing.T, extraArgs []string) {
+				assert.Contains(t, extraArgs, "--zone-id-filter=abc123")
+			},
+		},
+		{
+			name: "proxied and zone ID together",
+			config: &config.Config{
+				ClusterName: "my-cluster",
+				Addons: config.AddonsConfig{
+					ExternalDNS: config.ExternalDNSConfig{
+						Enabled: true,
+					},
+					Cloudflare: config.CloudflareConfig{
+						Domain:  "example.com",
+						Proxied: true,
+						ZoneID:  "xyz789",
+					},
+				},
+			},
+			expectedOwner:  "my-cluster",
+			expectedPolicy: "sync",
+			checkExtraArgs: func(t *testing.T, extraArgs []string) {
+				assert.Contains(t, extraArgs, "--cloudflare-proxied")
+				assert.Contains(t, extraArgs, "--zone-id-filter=xyz789")
+			},
+		},
+		{
+			name: "custom sources",
+			config: &config.Config{
+				ClusterName: "my-cluster",
+				Addons: config.AddonsConfig{
+					ExternalDNS: config.ExternalDNSConfig{
+						Enabled: true,
+						Sources: []string{"ingress", "service"},
+					},
+					Cloudflare: config.CloudflareConfig{
+						Domain: "example.com",
+					},
+				},
+			},
+			expectedOwner:  "my-cluster",
+			expectedPolicy: "sync",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := buildExternalDNSValues(tt.config)
+
+			// Check owner ID
+			assert.Equal(t, tt.expectedOwner, values["txtOwnerId"])
+
+			// Check policy
+			assert.Equal(t, tt.expectedPolicy, values["policy"])
+
+			// Check provider
+			provider := values["provider"].(helm.Values)
+			assert.Equal(t, "cloudflare", provider["name"])
+
+			// Check domain filters
+			domainFilters := values["domainFilters"].([]string)
+			if tt.config.Addons.Cloudflare.Domain != "" {
+				assert.Contains(t, domainFilters, tt.config.Addons.Cloudflare.Domain)
+			}
+
+			// Check extra args
+			if tt.checkExtraArgs != nil {
+				extraArgs := values["extraArgs"].([]string)
+				tt.checkExtraArgs(t, extraArgs)
+			}
+
+			// Check sources
+			sources := values["sources"].([]string)
+			if len(tt.config.Addons.ExternalDNS.Sources) > 0 {
+				assert.Equal(t, tt.config.Addons.ExternalDNS.Sources, sources)
+			} else {
+				assert.Equal(t, []string{"ingress"}, sources)
+			}
+		})
+	}
+}
+
+func TestBuildExternalDNSValues_StructureComplete(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Addons: config.AddonsConfig{
+			ExternalDNS: config.ExternalDNSConfig{
+				Enabled: true,
+			},
+			Cloudflare: config.CloudflareConfig{
+				Domain: "example.com",
+			},
+		},
+	}
+
+	values := buildExternalDNSValues(cfg)
+
+	// Check env vars for CF_API_TOKEN
+	env := values["env"].([]helm.Values)
+	require.Len(t, env, 1)
+	assert.Equal(t, "CF_API_TOKEN", env[0]["name"])
+
+	// Check node selector (should schedule on control plane)
+	nodeSelector := values["nodeSelector"].(helm.Values)
+	_, ok := nodeSelector["node-role.kubernetes.io/control-plane"]
+	assert.True(t, ok)
+
+	// Check tolerations
+	tolerations := values["tolerations"].([]helm.Values)
+	assert.Len(t, tolerations, 2)
+
+	// Check service account
+	serviceAccount := values["serviceAccount"].(helm.Values)
+	assert.True(t, serviceAccount["create"].(bool))
+	assert.Equal(t, "external-dns", serviceAccount["name"])
+
+	// Check RBAC
+	rbac := values["rbac"].(helm.Values)
+	assert.True(t, rbac["create"].(bool))
+
+	// Check other settings
+	assert.Equal(t, "info", values["logLevel"])
+	assert.Equal(t, "text", values["logFormat"])
+	assert.Equal(t, "1m", values["interval"])
+	assert.Equal(t, "txt", values["registry"])
+	assert.Equal(t, 1, values["replicaCount"])
+}
+
+func TestBuildExternalDNSValues_NoDomain(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Addons: config.AddonsConfig{
+			ExternalDNS: config.ExternalDNSConfig{
+				Enabled: true,
+			},
+			Cloudflare: config.CloudflareConfig{
+				// No domain set
+			},
+		},
+	}
+
+	values := buildExternalDNSValues(cfg)
+
+	domainFilters := values["domainFilters"].([]string)
+	assert.Empty(t, domainFilters)
+}
+
+func TestBuildExternalDNSValues_PDBConfig(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Addons: config.AddonsConfig{
+			ExternalDNS: config.ExternalDNSConfig{
+				Enabled: true,
+			},
+			Cloudflare: config.CloudflareConfig{
+				Domain: "example.com",
+			},
+		},
+	}
+
+	values := buildExternalDNSValues(cfg)
+
+	pdb := values["podDisruptionBudget"].(helm.Values)
+	assert.True(t, pdb["enabled"].(bool))
+	assert.Equal(t, 1, pdb["minAvailable"])
+}

--- a/internal/addons/helm/spec_test.go
+++ b/internal/addons/helm/spec_test.go
@@ -1,0 +1,197 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/imamik/k8zner/internal/config"
+)
+
+func TestGetChartSpec_KnownCharts(t *testing.T) {
+	tests := []struct {
+		name            string
+		chartName       string
+		expectedRepo    string
+		expectedChart   string
+		expectedVersion string
+	}{
+		{
+			name:            "hcloud-ccm",
+			chartName:       "hcloud-ccm",
+			expectedRepo:    "https://charts.hetzner.cloud",
+			expectedChart:   "hcloud-cloud-controller-manager",
+			expectedVersion: "1.29.0",
+		},
+		{
+			name:            "hcloud-csi",
+			chartName:       "hcloud-csi",
+			expectedRepo:    "https://charts.hetzner.cloud",
+			expectedChart:   "hcloud-csi",
+			expectedVersion: "2.18.3",
+		},
+		{
+			name:            "cilium",
+			chartName:       "cilium",
+			expectedRepo:    "https://helm.cilium.io",
+			expectedChart:   "cilium",
+			expectedVersion: "1.18.5",
+		},
+		{
+			name:            "cert-manager",
+			chartName:       "cert-manager",
+			expectedRepo:    "https://charts.jetstack.io",
+			expectedChart:   "cert-manager",
+			expectedVersion: "v1.19.2",
+		},
+		{
+			name:            "ingress-nginx",
+			chartName:       "ingress-nginx",
+			expectedRepo:    "https://kubernetes.github.io/ingress-nginx",
+			expectedChart:   "ingress-nginx",
+			expectedVersion: "4.11.3",
+		},
+		{
+			name:            "traefik",
+			chartName:       "traefik",
+			expectedRepo:    "https://traefik.github.io/charts",
+			expectedChart:   "traefik",
+			expectedVersion: "39.0.0",
+		},
+		{
+			name:            "metrics-server",
+			chartName:       "metrics-server",
+			expectedRepo:    "https://kubernetes-sigs.github.io/metrics-server",
+			expectedChart:   "metrics-server",
+			expectedVersion: "3.12.2",
+		},
+		{
+			name:            "cluster-autoscaler",
+			chartName:       "cluster-autoscaler",
+			expectedRepo:    "https://kubernetes.github.io/autoscaler",
+			expectedChart:   "cluster-autoscaler",
+			expectedVersion: "9.50.1",
+		},
+		{
+			name:            "longhorn",
+			chartName:       "longhorn",
+			expectedRepo:    "https://charts.longhorn.io",
+			expectedChart:   "longhorn",
+			expectedVersion: "1.10.1",
+		},
+		{
+			name:            "argo-cd",
+			chartName:       "argo-cd",
+			expectedRepo:    "https://argoproj.github.io/argo-helm",
+			expectedChart:   "argo-cd",
+			expectedVersion: "9.3.5",
+		},
+		{
+			name:            "external-dns",
+			chartName:       "external-dns",
+			expectedRepo:    "https://kubernetes-sigs.github.io/external-dns",
+			expectedChart:   "external-dns",
+			expectedVersion: "1.15.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := GetChartSpec(tt.chartName, config.HelmChartConfig{})
+
+			assert.Equal(t, tt.expectedRepo, spec.Repository)
+			assert.Equal(t, tt.expectedChart, spec.Name)
+			assert.Equal(t, tt.expectedVersion, spec.Version)
+		})
+	}
+}
+
+func TestGetChartSpec_UnknownChart(t *testing.T) {
+	spec := GetChartSpec("unknown-chart", config.HelmChartConfig{})
+
+	// Should return empty spec
+	assert.Empty(t, spec.Repository)
+	assert.Empty(t, spec.Name)
+	assert.Empty(t, spec.Version)
+}
+
+func TestGetChartSpec_WithRepositoryOverride(t *testing.T) {
+	helmCfg := config.HelmChartConfig{
+		Repository: "https://custom.repo.io",
+	}
+
+	spec := GetChartSpec("cilium", helmCfg)
+
+	assert.Equal(t, "https://custom.repo.io", spec.Repository)
+	assert.Equal(t, "cilium", spec.Name)    // Default chart name
+	assert.Equal(t, "1.18.5", spec.Version) // Default version
+}
+
+func TestGetChartSpec_WithChartOverride(t *testing.T) {
+	helmCfg := config.HelmChartConfig{
+		Chart: "custom-cilium",
+	}
+
+	spec := GetChartSpec("cilium", helmCfg)
+
+	assert.Equal(t, "https://helm.cilium.io", spec.Repository) // Default repo
+	assert.Equal(t, "custom-cilium", spec.Name)
+	assert.Equal(t, "1.18.5", spec.Version) // Default version
+}
+
+func TestGetChartSpec_WithVersionOverride(t *testing.T) {
+	helmCfg := config.HelmChartConfig{
+		Version: "1.16.0",
+	}
+
+	spec := GetChartSpec("cilium", helmCfg)
+
+	assert.Equal(t, "https://helm.cilium.io", spec.Repository) // Default repo
+	assert.Equal(t, "cilium", spec.Name)                       // Default chart name
+	assert.Equal(t, "1.16.0", spec.Version)
+}
+
+func TestGetChartSpec_WithAllOverrides(t *testing.T) {
+	helmCfg := config.HelmChartConfig{
+		Repository: "https://my-private-repo.io",
+		Chart:      "my-custom-chart",
+		Version:    "2.0.0",
+	}
+
+	spec := GetChartSpec("cert-manager", helmCfg)
+
+	assert.Equal(t, "https://my-private-repo.io", spec.Repository)
+	assert.Equal(t, "my-custom-chart", spec.Name)
+	assert.Equal(t, "2.0.0", spec.Version)
+}
+
+func TestDefaultChartSpecs_ContainsAllExpectedCharts(t *testing.T) {
+	expectedCharts := []string{
+		"hcloud-ccm",
+		"hcloud-csi",
+		"cilium",
+		"cert-manager",
+		"ingress-nginx",
+		"traefik",
+		"metrics-server",
+		"cluster-autoscaler",
+		"longhorn",
+		"argo-cd",
+		"external-dns",
+	}
+
+	for _, chartName := range expectedCharts {
+		_, exists := DefaultChartSpecs[chartName]
+		assert.True(t, exists, "Expected chart %s to be in DefaultChartSpecs", chartName)
+	}
+}
+
+func TestDefaultChartSpecs_AllHaveRequiredFields(t *testing.T) {
+	for name, spec := range DefaultChartSpecs {
+		t.Run(name, func(t *testing.T) {
+			assert.NotEmpty(t, spec.Repository, "Repository should not be empty for %s", name)
+			assert.NotEmpty(t, spec.Name, "Name should not be empty for %s", name)
+			assert.NotEmpty(t, spec.Version, "Version should not be empty for %s", name)
+		})
+	}
+}

--- a/internal/addons/k8sclient/apply_test.go
+++ b/internal/addons/k8sclient/apply_test.go
@@ -1,0 +1,275 @@
+package k8sclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/restmapper"
+)
+
+// Note: Server-Side Apply tests require a real cluster or more sophisticated fakes.
+// These tests focus on input validation, error handling, and interface compliance.
+
+func TestApplyManifests_EmptyManifest(t *testing.T) {
+	manifests := []byte(``)
+
+	client := setupApplyTestClient(t)
+
+	err := client.ApplyManifests(context.Background(), manifests, "test-manager")
+	require.NoError(t, err)
+}
+
+func TestApplyManifests_InvalidYAML(t *testing.T) {
+	manifests := []byte(`{invalid yaml: [`)
+
+	client := setupApplyTestClient(t)
+
+	err := client.ApplyManifests(context.Background(), manifests, "test-manager")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode manifest")
+}
+
+func TestApplyManifests_NoKindInDocument(t *testing.T) {
+	// YAML without kind field - decoder will fail
+	manifests := []byte(`apiVersion: v1
+metadata:
+  name: test
+`)
+
+	client := setupApplyTestClient(t)
+
+	err := client.ApplyManifests(context.Background(), manifests, "test-manager")
+	require.Error(t, err)
+	// The decoder catches missing Kind
+	assert.Contains(t, err.Error(), "Kind")
+}
+
+func TestApplyManifests_EmptyDocuments(t *testing.T) {
+	// Multiple empty documents should be skipped
+	manifests := []byte(`---
+---
+---
+`)
+
+	client := setupApplyTestClient(t)
+
+	err := client.ApplyManifests(context.Background(), manifests, "test-manager")
+	require.NoError(t, err)
+}
+
+func TestNewFromKubeconfig_InvalidKubeconfig(t *testing.T) {
+	invalidKubeconfig := []byte(`invalid kubeconfig content`)
+
+	_, err := NewFromKubeconfig(invalidKubeconfig)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create REST config")
+}
+
+func TestNewFromKubeconfig_EmptyKubeconfig(t *testing.T) {
+	_, err := NewFromKubeconfig([]byte{})
+	require.Error(t, err)
+}
+
+// setupApplyTestClient creates a test client with fake clients
+func setupApplyTestClient(t *testing.T) Client {
+	t.Helper()
+
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+	mapper := createApplyTestMapper()
+
+	return NewFromClients(clientset, dynamicClient, mapper)
+}
+
+// createApplyTestMapper creates a REST mapper for testing
+func createApplyTestMapper() meta.RESTMapper {
+	resources := []*restmapper.APIGroupResources{
+		{
+			Group: metav1.APIGroup{
+				Name: "",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "v1", Version: "v1"},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: "v1",
+					Version:      "v1",
+				},
+			},
+			VersionedResources: map[string][]metav1.APIResource{
+				"v1": {
+					{Name: "configmaps", Namespaced: true, Kind: "ConfigMap"},
+					{Name: "secrets", Namespaced: true, Kind: "Secret"},
+					{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
+					{Name: "services", Namespaced: true, Kind: "Service"},
+				},
+			},
+		},
+	}
+
+	return restmapper.NewDiscoveryRESTMapper(resources)
+}
+
+func TestClient_Interface(t *testing.T) {
+	// Verify that client implements the Client interface
+	var _ Client = &client{}
+}
+
+func TestApplyObject_NoKind(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+	mapper := createApplyTestMapper()
+
+	c := &client{
+		clientset:     clientset,
+		dynamicClient: dynamicClient,
+		mapper:        mapper,
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name": "test",
+			},
+		},
+	}
+
+	err := c.applyObject(context.Background(), obj, "test-manager")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no kind set")
+}
+
+func TestApplyObject_UnknownGVK(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
+	mapper := createApplyTestMapper()
+
+	c := &client{
+		clientset:     clientset,
+		dynamicClient: dynamicClient,
+		mapper:        mapper,
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "unknown.io/v1",
+			"kind":       "UnknownResource",
+			"metadata": map[string]interface{}{
+				"name": "test",
+			},
+		},
+	}
+
+	err := c.applyObject(context.Background(), obj, "test-manager")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get REST mapping")
+}
+
+func TestGVKMapping(t *testing.T) {
+	mapper := createApplyTestMapper()
+
+	tests := []struct {
+		gvk         schema.GroupVersionKind
+		expectedGVR schema.GroupVersionResource
+		expectErr   bool
+	}{
+		{
+			gvk:         schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+			expectedGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+		},
+		{
+			gvk:         schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+			expectedGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+		},
+		{
+			gvk:         schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+			expectedGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.gvk.Kind, func(t *testing.T) {
+			mapping, err := mapper.RESTMapping(tt.gvk.GroupKind(), tt.gvk.Version)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedGVR, mapping.Resource)
+			}
+		})
+	}
+}
+
+func TestUnstructured_MarshalJSON(t *testing.T) {
+	// Test that unstructured objects can be marshaled to JSON for SSA
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "default",
+			},
+			"data": map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	data, err := obj.MarshalJSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"apiVersion":"v1"`)
+	assert.Contains(t, string(data), `"kind":"ConfigMap"`)
+	assert.Contains(t, string(data), `"name":"test-cm"`)
+}
+
+func TestUnstructured_GetGVK(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": "test",
+			},
+		},
+	}
+
+	gvk := obj.GroupVersionKind()
+	assert.Equal(t, "", gvk.Group)
+	assert.Equal(t, "v1", gvk.Version)
+	assert.Equal(t, "ConfigMap", gvk.Kind)
+}
+
+func TestUnstructured_GetMetadata(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "test-cm",
+				"namespace": "kube-system",
+			},
+		},
+	}
+
+	assert.Equal(t, "test-cm", obj.GetName())
+	assert.Equal(t, "kube-system", obj.GetNamespace())
+}

--- a/internal/addons/k8sclient/secret_test.go
+++ b/internal/addons/k8sclient/secret_test.go
@@ -1,0 +1,233 @@
+package k8sclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestCreateSecret_Success(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	c := &client{clientset: clientset}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"key": []byte("value"),
+		},
+	}
+
+	err := c.CreateSecret(context.Background(), secret)
+	require.NoError(t, err)
+
+	// Verify secret was created
+	created, err := clientset.CoreV1().Secrets("default").Get(context.Background(), "test-secret", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "test-secret", created.Name)
+	assert.Equal(t, []byte("value"), created.Data["key"])
+}
+
+func TestCreateSecret_MissingNamespace(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	c := &client{clientset: clientset}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-secret",
+			// Missing namespace
+		},
+	}
+
+	err := c.CreateSecret(context.Background(), secret)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret namespace is required")
+}
+
+func TestCreateSecret_MissingName(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	c := &client{clientset: clientset}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			// Missing name
+		},
+	}
+
+	err := c.CreateSecret(context.Background(), secret)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name is required")
+}
+
+func TestCreateSecret_ReplacesExisting(t *testing.T) {
+	// Create existing secret
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"old-key": []byte("old-value"),
+		},
+	}
+
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset(existingSecret)
+
+	c := &client{clientset: clientset}
+
+	// Create new secret with same name
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"new-key": []byte("new-value"),
+		},
+	}
+
+	err := c.CreateSecret(context.Background(), newSecret)
+	require.NoError(t, err)
+
+	// Verify secret was replaced
+	created, err := clientset.CoreV1().Secrets("default").Get(context.Background(), "test-secret", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new-value"), created.Data["new-key"])
+	_, hasOldKey := created.Data["old-key"]
+	assert.False(t, hasOldKey, "old key should not exist in replaced secret")
+}
+
+func TestCreateSecret_DeleteError(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	// Add reactor to fail delete operations
+	clientset.PrependReactor("delete", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, errors.NewForbidden(corev1.Resource("secrets"), "test-secret", nil)
+	})
+
+	c := &client{clientset: clientset}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+	}
+
+	err := c.CreateSecret(context.Background(), secret)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete existing secret")
+}
+
+func TestCreateSecret_CreateError(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	// Add reactor to fail create operations
+	clientset.PrependReactor("create", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, errors.NewServiceUnavailable("service unavailable")
+	})
+
+	c := &client{clientset: clientset}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+	}
+
+	err := c.CreateSecret(context.Background(), secret)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create secret")
+}
+
+func TestDeleteSecret_Success(t *testing.T) {
+	// Create existing secret
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+	}
+
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset(existingSecret)
+
+	c := &client{clientset: clientset}
+
+	err := c.DeleteSecret(context.Background(), "default", "test-secret")
+	require.NoError(t, err)
+
+	// Verify secret was deleted
+	_, err = clientset.CoreV1().Secrets("default").Get(context.Background(), "test-secret", metav1.GetOptions{})
+	require.True(t, errors.IsNotFound(err))
+}
+
+func TestDeleteSecret_NotFound(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	c := &client{clientset: clientset}
+
+	// Deleting non-existent secret should succeed
+	err := c.DeleteSecret(context.Background(), "default", "nonexistent")
+	require.NoError(t, err)
+}
+
+func TestDeleteSecret_MissingNamespace(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	c := &client{clientset: clientset}
+
+	err := c.DeleteSecret(context.Background(), "", "test-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "namespace is required")
+}
+
+func TestDeleteSecret_MissingName(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	c := &client{clientset: clientset}
+
+	err := c.DeleteSecret(context.Background(), "default", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name is required")
+}
+
+func TestDeleteSecret_Error(t *testing.T) {
+	//nolint:staticcheck // SA1019: NewSimpleClientset is sufficient for our testing needs
+	clientset := fake.NewSimpleClientset()
+
+	// Add reactor to fail delete operations
+	clientset.PrependReactor("delete", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, errors.NewForbidden(corev1.Resource("secrets"), "test-secret", nil)
+	})
+
+	c := &client{clientset: clientset}
+
+	err := c.DeleteSecret(context.Background(), "default", "test-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete secret")
+}

--- a/internal/addons/kubectl_test.go
+++ b/internal/addons/kubectl_test.go
@@ -1,0 +1,185 @@
+package addons
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// mockK8sClient is a local mock for testing
+type mockK8sClient struct {
+	mock.Mock
+}
+
+func (m *mockK8sClient) ApplyManifests(ctx context.Context, manifests []byte, fieldManager string) error {
+	args := m.Called(ctx, manifests, fieldManager)
+	return args.Error(0)
+}
+
+func (m *mockK8sClient) CreateSecret(ctx context.Context, secret *corev1.Secret) error {
+	args := m.Called(ctx, secret)
+	return args.Error(0)
+}
+
+func (m *mockK8sClient) DeleteSecret(ctx context.Context, namespace, name string) error {
+	args := m.Called(ctx, namespace, name)
+	return args.Error(0)
+}
+
+func TestApplyManifests(t *testing.T) {
+	tests := []struct {
+		name        string
+		addonName   string
+		manifests   []byte
+		mockErr     error
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:      "success",
+			addonName: "test-addon",
+			manifests: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test"),
+			mockErr:   nil,
+			expectErr: false,
+		},
+		{
+			name:        "apply error",
+			addonName:   "test-addon",
+			manifests:   []byte("apiVersion: v1\nkind: ConfigMap"),
+			mockErr:     errors.New("apply failed"),
+			expectErr:   true,
+			errContains: "failed to apply manifests for addon test-addon",
+		},
+		{
+			name:      "empty manifest",
+			addonName: "test-addon",
+			manifests: []byte{},
+			mockErr:   nil,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := new(mockK8sClient)
+			client.On("ApplyManifests", mock.Anything, tt.manifests, tt.addonName).Return(tt.mockErr)
+
+			err := applyManifests(context.Background(), client, tt.addonName, tt.manifests)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestApplyFromURL_Success(t *testing.T) {
+	manifestContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+  namespace: default
+data:
+  key: value`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(manifestContent))
+	}))
+	defer server.Close()
+
+	client := new(mockK8sClient)
+	client.On("ApplyManifests", mock.Anything, []byte(manifestContent), "test-addon").Return(nil)
+
+	err := applyFromURL(context.Background(), client, "test-addon", server.URL)
+	require.NoError(t, err)
+	client.AssertExpectations(t)
+}
+
+func TestApplyFromURL_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := new(mockK8sClient)
+
+	err := applyFromURL(context.Background(), client, "test-addon", server.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestApplyFromURL_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := new(mockK8sClient)
+
+	err := applyFromURL(context.Background(), client, "test-addon", server.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 500")
+}
+
+func TestApplyFromURL_InvalidURL(t *testing.T) {
+	client := new(mockK8sClient)
+
+	err := applyFromURL(context.Background(), client, "test-addon", "http://[::1]:namedport")
+	require.Error(t, err)
+	// Could fail on request creation or download
+	assert.True(t,
+		strings.Contains(err.Error(), "failed to download manifest") ||
+			strings.Contains(err.Error(), "failed to create request"),
+		"Expected error about download or request creation, got: %s", err.Error())
+}
+
+func TestApplyFromURL_ApplyError(t *testing.T) {
+	manifestContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(manifestContent))
+	}))
+	defer server.Close()
+
+	client := new(mockK8sClient)
+	client.On("ApplyManifests", mock.Anything, []byte(manifestContent), "test-addon").Return(errors.New("apply failed"))
+
+	err := applyFromURL(context.Background(), client, "test-addon", server.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to apply manifests for addon test-addon")
+}
+
+func TestApplyFromURL_ContextCanceled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow response that will be canceled
+		select {
+		case <-r.Context().Done():
+			return
+		}
+	}))
+	defer server.Close()
+
+	client := new(mockK8sClient)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	err := applyFromURL(ctx, client, "test-addon", server.URL)
+	require.Error(t, err)
+}

--- a/internal/addons/secret_test.go
+++ b/internal/addons/secret_test.go
@@ -1,0 +1,119 @@
+package addons
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Note: Uses mockK8sClient from kubectl_test.go (same package)
+
+func TestCreateHCloudSecret(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		networkID   int64
+		mockErr     error
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:      "success",
+			token:     "test-token",
+			networkID: 12345,
+			mockErr:   nil,
+			expectErr: false,
+		},
+		{
+			name:        "client error",
+			token:       "test-token",
+			networkID:   12345,
+			mockErr:     errors.New("create failed"),
+			expectErr:   true,
+			errContains: "failed to create hcloud secret",
+		},
+		{
+			name:      "large network ID",
+			token:     "test-token",
+			networkID: 9999999999,
+			mockErr:   nil,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := new(mockK8sClient)
+
+			// Capture the secret to verify its structure
+			var capturedSecret *corev1.Secret
+			client.On("CreateSecret", mock.Anything, mock.AnythingOfType("*v1.Secret")).Run(func(args mock.Arguments) {
+				capturedSecret = args.Get(1).(*corev1.Secret)
+			}).Return(tt.mockErr)
+
+			err := createHCloudSecret(context.Background(), client, tt.token, tt.networkID)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+
+				// Verify secret structure
+				require.NotNil(t, capturedSecret)
+				assert.Equal(t, "hcloud", capturedSecret.Name)
+				assert.Equal(t, "kube-system", capturedSecret.Namespace)
+				assert.Equal(t, corev1.SecretTypeOpaque, capturedSecret.Type)
+				assert.Equal(t, tt.token, capturedSecret.StringData["token"])
+				assert.Contains(t, capturedSecret.StringData["network"], "")
+			}
+
+			client.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCreateHCloudSecret_NetworkIDFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		networkID      int64
+		expectedString string
+	}{
+		{
+			name:           "single digit",
+			networkID:      1,
+			expectedString: "1",
+		},
+		{
+			name:           "multiple digits",
+			networkID:      12345,
+			expectedString: "12345",
+		},
+		{
+			name:           "large number",
+			networkID:      1234567890,
+			expectedString: "1234567890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := new(mockK8sClient)
+
+			var capturedSecret *corev1.Secret
+			client.On("CreateSecret", mock.Anything, mock.AnythingOfType("*v1.Secret")).Run(func(args mock.Arguments) {
+				capturedSecret = args.Get(1).(*corev1.Secret)
+			}).Return(nil)
+
+			err := createHCloudSecret(context.Background(), client, "token", tt.networkID)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedString, capturedSecret.StringData["network"])
+		})
+	}
+}

--- a/internal/config/wizard/options_test.go
+++ b/internal/config/wizard/options_test.go
@@ -1,0 +1,192 @@
+package wizard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Additional tests for options.go that complement wizard_test.go
+// Note: TestFilterServerTypes, TestLocationsToOptions, TestServerTypesToOptions,
+// and TestVersionsToOptions are already defined in wizard_test.go
+
+func TestFilterServerTypes_X86Shared(t *testing.T) {
+	filtered := FilterServerTypes(ArchX86, CategoryShared)
+
+	require.NotEmpty(t, filtered)
+	for _, st := range filtered {
+		assert.Equal(t, ArchX86, st.Architecture)
+		assert.Equal(t, CategoryShared, st.Category)
+	}
+
+	// Check specific types are included
+	values := extractValuesFromTypes(filtered)
+	assert.Contains(t, values, "cpx11")
+	assert.Contains(t, values, "cpx21")
+	assert.Contains(t, values, "cpx31")
+}
+
+func TestFilterServerTypes_X86Dedicated(t *testing.T) {
+	filtered := FilterServerTypes(ArchX86, CategoryDedicated)
+
+	require.NotEmpty(t, filtered)
+	for _, st := range filtered {
+		assert.Equal(t, ArchX86, st.Architecture)
+		assert.Equal(t, CategoryDedicated, st.Category)
+	}
+
+	// Check specific types are included
+	values := extractValuesFromTypes(filtered)
+	assert.Contains(t, values, "ccx13")
+	assert.Contains(t, values, "ccx23")
+	assert.Contains(t, values, "ccx33")
+}
+
+func TestFilterServerTypes_X86CostOptimized(t *testing.T) {
+	filtered := FilterServerTypes(ArchX86, CategoryCostOptimized)
+
+	require.NotEmpty(t, filtered)
+	for _, st := range filtered {
+		assert.Equal(t, ArchX86, st.Architecture)
+		assert.Equal(t, CategoryCostOptimized, st.Category)
+	}
+
+	// Check specific types are included
+	values := extractValuesFromTypes(filtered)
+	assert.Contains(t, values, "cx22")
+	assert.Contains(t, values, "cx32")
+}
+
+func TestFilterServerTypes_ARMShared(t *testing.T) {
+	filtered := FilterServerTypes(ArchARM, CategoryShared)
+
+	require.NotEmpty(t, filtered)
+	for _, st := range filtered {
+		assert.Equal(t, ArchARM, st.Architecture)
+		assert.Equal(t, CategoryShared, st.Category)
+	}
+
+	// Check specific types are included
+	values := extractValuesFromTypes(filtered)
+	assert.Contains(t, values, "cax11")
+	assert.Contains(t, values, "cax21")
+	assert.Contains(t, values, "cax31")
+	assert.Contains(t, values, "cax41")
+}
+
+func TestFilterServerTypes_NoMatch(t *testing.T) {
+	// ARM doesn't have dedicated or cost-optimized options
+	filtered := FilterServerTypes(ArchARM, CategoryDedicated)
+	assert.Empty(t, filtered)
+
+	filtered = FilterServerTypes(ArchARM, CategoryCostOptimized)
+	assert.Empty(t, filtered)
+}
+
+func TestFilterServerTypes_InvalidArchitecture(t *testing.T) {
+	filtered := FilterServerTypes("invalid", CategoryShared)
+	assert.Empty(t, filtered)
+}
+
+func TestFilterServerTypes_InvalidCategory(t *testing.T) {
+	filtered := FilterServerTypes(ArchX86, "invalid")
+	assert.Empty(t, filtered)
+}
+
+func TestServerTypesToOptions_Empty(t *testing.T) {
+	opts := ServerTypesToOptions([]ServerTypeOption{})
+	assert.Empty(t, opts)
+}
+
+func TestVersionsToOptions_Empty(t *testing.T) {
+	opts := VersionsToOptions([]VersionOption{})
+	assert.Empty(t, opts)
+}
+
+func TestAllServerTypes_Complete(t *testing.T) {
+	// Verify all server types have required fields
+	for _, st := range AllServerTypes {
+		assert.NotEmpty(t, st.Value, "Value should not be empty")
+		assert.NotEmpty(t, st.Label, "Label should not be empty")
+		assert.NotEmpty(t, st.Description, "Description should not be empty")
+		assert.NotEmpty(t, st.Architecture, "Architecture should not be empty")
+		assert.NotEmpty(t, st.Category, "Category should not be empty")
+	}
+}
+
+func TestLocations_Complete(t *testing.T) {
+	for _, loc := range Locations {
+		assert.NotEmpty(t, loc.Value, "Value should not be empty")
+		assert.NotEmpty(t, loc.Label, "Label should not be empty")
+		assert.NotEmpty(t, loc.Description, "Description should not be empty")
+	}
+}
+
+func TestEULocations_Subset(t *testing.T) {
+	// EU locations should be a subset of all locations
+	allValues := make(map[string]bool)
+	for _, loc := range Locations {
+		allValues[loc.Value] = true
+	}
+
+	for _, loc := range EULocations {
+		assert.True(t, allValues[loc.Value], "EU location %s should be in all locations", loc.Value)
+	}
+}
+
+func TestTalosVersions_NotEmpty(t *testing.T) {
+	assert.NotEmpty(t, TalosVersions)
+
+	for _, v := range TalosVersions {
+		assert.NotEmpty(t, v.Value)
+		assert.NotEmpty(t, v.Label)
+	}
+}
+
+func TestKubernetesVersions_NotEmpty(t *testing.T) {
+	assert.NotEmpty(t, KubernetesVersions)
+
+	for _, v := range KubernetesVersions {
+		assert.NotEmpty(t, v.Value)
+		assert.NotEmpty(t, v.Label)
+	}
+}
+
+func TestBasicAddons_Complete(t *testing.T) {
+	for _, addon := range BasicAddons {
+		assert.NotEmpty(t, addon.Key, "Key should not be empty")
+		assert.NotEmpty(t, addon.Label, "Label should not be empty")
+		assert.NotEmpty(t, addon.Description, "Description should not be empty")
+	}
+}
+
+func TestConstants(t *testing.T) {
+	// Architecture constants
+	assert.Equal(t, "x86", ArchX86)
+	assert.Equal(t, "arm", ArchARM)
+
+	// Category constants
+	assert.Equal(t, "shared", CategoryShared)
+	assert.Equal(t, "dedicated", CategoryDedicated)
+	assert.Equal(t, "cost-optimized", CategoryCostOptimized)
+
+	// CNI constants
+	assert.Equal(t, "cilium", CNICilium)
+	assert.Equal(t, "talos", CNITalosNative)
+	assert.Equal(t, "none", CNINone)
+
+	// Ingress constants
+	assert.Equal(t, "none", IngressNone)
+	assert.Equal(t, "nginx", IngressNginx)
+	assert.Equal(t, "traefik", IngressTraefik)
+}
+
+// extractValuesFromTypes is a helper to get values from ServerTypeOption slice
+func extractValuesFromTypes(types []ServerTypeOption) []string {
+	values := make([]string, len(types))
+	for i, t := range types {
+		values[i] = t.Value
+	}
+	return values
+}

--- a/internal/config/wizard/writer_test.go
+++ b/internal/config/wizard/writer_test.go
@@ -1,0 +1,450 @@
+package wizard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/imamik/k8zner/internal/config"
+)
+
+func TestWriteConfig_MinimalOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "cluster.yaml")
+
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	err := WriteConfig(cfg, outputPath, false)
+	require.NoError(t, err)
+
+	// Read the file
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	// Check header
+	assert.Contains(t, string(content), "# k8zner cluster configuration")
+	assert.Contains(t, string(content), "Output mode: minimal")
+
+	// Check cluster name
+	assert.Contains(t, string(content), "cluster_name: test-cluster")
+}
+
+func TestWriteConfig_FullOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "cluster.yaml")
+
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	err := WriteConfig(cfg, outputPath, true)
+	require.NoError(t, err)
+
+	// Read the file
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	// Check header
+	assert.Contains(t, string(content), "Output mode: full")
+	assert.NotContains(t, string(content), "Note: This is a minimal config")
+}
+
+func TestWriteConfig_WithWorkers(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "cluster.yaml")
+
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Workers: []config.WorkerNodePool{
+			{Name: "worker", ServerType: "cpx31", Count: 3},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	err := WriteConfig(cfg, outputPath, false)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), "workers:")
+}
+
+func TestWriteConfig_WithAddons(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "cluster.yaml")
+
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+		Addons: config.AddonsConfig{
+			Cilium: config.CiliumConfig{
+				Enabled:           true,
+				EncryptionEnabled: true,
+				EncryptionType:    "wireguard",
+			},
+			CCM: config.CCMConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	err := WriteConfig(cfg, outputPath, false)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), "addons:")
+	assert.Contains(t, string(content), "cilium:")
+	assert.Contains(t, string(content), "enabled: true")
+}
+
+func TestWriteConfig_FilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "cluster.yaml")
+
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	err := WriteConfig(cfg, outputPath, false)
+	require.NoError(t, err)
+
+	info, err := os.Stat(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestWriteConfig_InvalidPath(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+	}
+
+	err := WriteConfig(cfg, "/nonexistent/dir/cluster.yaml", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write file")
+}
+
+func TestBuildMinimalConfig(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		SSHKeys:     []string{"key1", "key2"},
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Workers: []config.WorkerNodePool{
+			{Name: "worker", ServerType: "cpx31", Count: 3},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	minCfg := buildMinimalConfig(cfg)
+
+	assert.Equal(t, "test-cluster", minCfg.ClusterName)
+	assert.Equal(t, "nbg1", minCfg.Location)
+	assert.Equal(t, []string{"key1", "key2"}, minCfg.SSHKeys)
+	assert.Len(t, minCfg.ControlPlane.NodePools, 1)
+	assert.Len(t, minCfg.Workers, 1)
+	assert.Equal(t, "v1.9.0", minCfg.Talos.Version)
+	assert.Equal(t, "v1.32.0", minCfg.Kubernetes.Version)
+}
+
+func TestBuildMinimalConfig_WithNetwork(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+		Network: config.NetworkConfig{
+			IPv4CIDR:        "10.0.0.0/8",
+			PodIPv4CIDR:     "10.244.0.0/16",
+			ServiceIPv4CIDR: "10.96.0.0/12",
+		},
+	}
+
+	minCfg := buildMinimalConfig(cfg)
+
+	require.NotNil(t, minCfg.Network)
+	assert.Equal(t, "10.0.0.0/8", minCfg.Network.IPv4CIDR)
+	assert.Equal(t, "10.244.0.0/16", minCfg.Network.PodIPv4CIDR)
+	assert.Equal(t, "10.96.0.0/12", minCfg.Network.ServiceIPv4CIDR)
+}
+
+func TestBuildMinimalConfig_WithEncryption(t *testing.T) {
+	stateEncryption := true
+	ephemeralEncryption := true
+
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+			Machine: config.TalosMachineConfig{
+				StateEncryption:     &stateEncryption,
+				EphemeralEncryption: &ephemeralEncryption,
+			},
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	minCfg := buildMinimalConfig(cfg)
+
+	require.NotNil(t, minCfg.Talos.MachineEncrypt)
+	assert.True(t, *minCfg.Talos.MachineEncrypt.StateEncryption)
+	assert.True(t, *minCfg.Talos.MachineEncrypt.EphemeralEncryption)
+}
+
+func TestBuildMinimalConfig_PrivateClusterAccess(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName:   "test-cluster",
+		Location:      "nbg1",
+		ClusterAccess: "private",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	minCfg := buildMinimalConfig(cfg)
+	assert.Equal(t, "private", minCfg.ClusterAccess)
+}
+
+func TestBuildMinimalConfig_PublicClusterAccessOmitted(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName:   "test-cluster",
+		Location:      "nbg1",
+		ClusterAccess: "public", // Default, should be omitted
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	minCfg := buildMinimalConfig(cfg)
+	assert.Empty(t, minCfg.ClusterAccess)
+}
+
+func TestGenerateHeader(t *testing.T) {
+	header := generateHeader("cluster.yaml", false)
+
+	assert.Contains(t, header, "# k8zner cluster configuration")
+	assert.Contains(t, header, "Generated by: k8zner init")
+	assert.Contains(t, header, "Output mode: minimal")
+	assert.Contains(t, header, "cluster.yaml")
+	assert.Contains(t, header, "HCLOUD_TOKEN")
+}
+
+func TestGenerateHeader_FullMode(t *testing.T) {
+	header := generateHeader("cluster.yaml", true)
+
+	assert.Contains(t, header, "Output mode: full")
+	assert.NotContains(t, header, "Note: This is a minimal config")
+}
+
+func TestGenerateHeader_ContainsTimestamp(t *testing.T) {
+	header := generateHeader("cluster.yaml", false)
+
+	// Should contain a timestamp in RFC3339 format
+	assert.True(t, strings.Contains(header, "Generated at:"))
+}
+
+func TestBuildMinimalConfig_AllAddons(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+		Addons: config.AddonsConfig{
+			Cilium: config.CiliumConfig{
+				Enabled:            true,
+				EncryptionEnabled:  true,
+				EncryptionType:     "wireguard",
+				HubbleEnabled:      true,
+				HubbleRelayEnabled: true,
+				GatewayAPIEnabled:  true,
+			},
+			CCM:           config.CCMConfig{Enabled: true},
+			CSI:           config.CSIConfig{Enabled: true},
+			MetricsServer: config.MetricsServerConfig{Enabled: true},
+			CertManager:   config.CertManagerConfig{Enabled: true},
+			IngressNginx:  config.IngressNginxConfig{Enabled: true},
+			Longhorn:      config.LonghornConfig{Enabled: true},
+			ArgoCD:        config.ArgoCDConfig{Enabled: true},
+		},
+	}
+
+	minCfg := buildMinimalConfig(cfg)
+
+	// Check all addons are included
+	require.NotNil(t, minCfg.Addons.Cilium)
+	assert.True(t, minCfg.Addons.Cilium.Enabled)
+	assert.True(t, minCfg.Addons.Cilium.EncryptionEnabled)
+	assert.Equal(t, "wireguard", minCfg.Addons.Cilium.EncryptionType)
+	assert.True(t, minCfg.Addons.Cilium.HubbleEnabled)
+	assert.True(t, minCfg.Addons.Cilium.HubbleRelayEnabled)
+	assert.True(t, minCfg.Addons.Cilium.GatewayAPIEnabled)
+
+	require.NotNil(t, minCfg.Addons.CCM)
+	assert.True(t, minCfg.Addons.CCM.Enabled)
+
+	require.NotNil(t, minCfg.Addons.CSI)
+	assert.True(t, minCfg.Addons.CSI.Enabled)
+
+	require.NotNil(t, minCfg.Addons.MetricsServer)
+	assert.True(t, minCfg.Addons.MetricsServer.Enabled)
+
+	require.NotNil(t, minCfg.Addons.CertManager)
+	assert.True(t, minCfg.Addons.CertManager.Enabled)
+
+	require.NotNil(t, minCfg.Addons.IngressNginx)
+	assert.True(t, minCfg.Addons.IngressNginx.Enabled)
+
+	require.NotNil(t, minCfg.Addons.Longhorn)
+	assert.True(t, minCfg.Addons.Longhorn.Enabled)
+
+	require.NotNil(t, minCfg.Addons.ArgoCD)
+	assert.True(t, minCfg.Addons.ArgoCD.Enabled)
+}
+
+func TestBuildMinimalConfig_NoAddons(t *testing.T) {
+	cfg := &config.Config{
+		ClusterName: "test-cluster",
+		Location:    "nbg1",
+		ControlPlane: config.ControlPlaneConfig{
+			NodePools: []config.ControlPlaneNodePool{
+				{Name: "control-plane", ServerType: "cpx21", Count: 1},
+			},
+		},
+		Talos: config.TalosConfig{
+			Version: "v1.9.0",
+		},
+		Kubernetes: config.KubernetesConfig{
+			Version: "v1.32.0",
+		},
+	}
+
+	minCfg := buildMinimalConfig(cfg)
+
+	// No addons should be included
+	assert.Nil(t, minCfg.Addons.Cilium)
+	assert.Nil(t, minCfg.Addons.CCM)
+	assert.Nil(t, minCfg.Addons.CSI)
+	assert.Nil(t, minCfg.Addons.MetricsServer)
+	assert.Nil(t, minCfg.Addons.CertManager)
+	assert.Nil(t, minCfg.Addons.IngressNginx)
+	assert.Nil(t, minCfg.Addons.Longhorn)
+	assert.Nil(t, minCfg.Addons.ArgoCD)
+}


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests to improve code coverage across `cmd/`, `internal/config/`, and `internal/addons/` packages
- Add `MockK8sClient` to `internal/testing/mocks.go` for addon testing
- Achieve >80% coverage target for `cmd/k8zner/commands` (89.6%) and `internal/config` (83.6%)

## Coverage Results

| Package | Coverage |
|---------|----------|
| `cmd/k8zner/commands` | **89.6%** ✓ |
| `cmd/k8zner/handlers` | 56.1% |
| `internal/config` | **83.6%** ✓ |
| `internal/config/wizard` | 57.8% |
| `internal/addons` | 59.6% |
| `internal/addons/helm` | 62.1% |
| `internal/addons/k8sclient` | 54.5% |

## New Test Files

**Commands:**
- `cmd/k8zner/commands/root_test.go`
- `cmd/k8zner/commands/apply_test.go`
- `cmd/k8zner/commands/init_test.go`
- `cmd/k8zner/commands/upgrade_test.go`
- `cmd/k8zner/commands/destroy_test.go`
- `cmd/k8zner/commands/version_test.go`
- `cmd/k8zner/commands/completion_test.go`
- `cmd/k8zner/commands/image_test.go`

**Handlers:**
- `cmd/k8zner/handlers/upgrade_test.go`

**Addons:**
- `internal/addons/kubectl_test.go`
- `internal/addons/secret_test.go`
- `internal/addons/external_dns_test.go`
- `internal/addons/cert_manager_cloudflare_test.go`
- `internal/addons/cloudflare_secret_test.go`
- `internal/addons/helm/spec_test.go`
- `internal/addons/k8sclient/apply_test.go`
- `internal/addons/k8sclient/secret_test.go`

**Config:**
- `internal/config/wizard/options_test.go`
- `internal/config/wizard/writer_test.go`
- `internal/config/validate_test.go` (extended with ApplyDefaults tests)

## Test plan

- [x] All tests pass: `go test ./cmd/... ./internal/config/... ./internal/addons/...`
- [x] No regressions in existing functionality
- [x] Coverage verified with `go test -cover`

🤖 Generated with [Claude Code](https://claude.com/claude-code)