### PR TITLE
test: improve unit test coverage for helm, handlers, and k8sclient

### DIFF
--- a/cmd/k8zner/handlers/init_test.go
+++ b/cmd/k8zner/handlers/init_test.go
@@ -139,3 +139,44 @@ func TestPrintInitSuccess_OutputPath(t *testing.T) {
 	assert.True(t, strings.Count(output, customPath) >= 2,
 		"Output path should appear at least twice (file location and apply command)")
 }
+
+func TestFormatCNIChoice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "cilium",
+			input:    wizard.CNICilium,
+			expected: "Cilium",
+		},
+		{
+			name:     "talos native",
+			input:    wizard.CNITalosNative,
+			expected: "Talos Default (Flannel)",
+		},
+		{
+			name:     "none",
+			input:    wizard.CNINone,
+			expected: "None (user-managed)",
+		},
+		{
+			name:     "unknown returns as-is",
+			input:    "custom-cni",
+			expected: "custom-cni",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatCNIChoice(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/cmd/k8zner/handlers/upgrade_test.go
+++ b/cmd/k8zner/handlers/upgrade_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,8 +80,8 @@ location: ""
 	require.Error(t, err)
 	// Either fails on validation or config load
 	assert.True(t,
-		contains(err.Error(), "invalid configuration") ||
-			contains(err.Error(), "failed to load config"),
+		strings.Contains(err.Error(), "invalid configuration") ||
+			strings.Contains(err.Error(), "failed to load config"),
 	)
 }
 
@@ -113,9 +114,9 @@ control_plane:
 	require.Error(t, err)
 	// Should fail on either secrets or validation
 	assert.True(t,
-		contains(err.Error(), "secrets") ||
-			contains(err.Error(), "invalid configuration") ||
-			contains(err.Error(), "failed to load"),
+		strings.Contains(err.Error(), "secrets") ||
+			strings.Contains(err.Error(), "invalid configuration") ||
+			strings.Contains(err.Error(), "failed to load"),
 	)
 }
 
@@ -127,18 +128,4 @@ func TestUpgrade_K8sVersionOverride(t *testing.T) {
 	}
 
 	assert.Equal(t, "v1.32.0", opts.K8sVersion)
-}
-
-// contains is a helper function for error checking
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr, 0))
-}
-
-func containsAt(s, substr string, start int) bool {
-	for i := start; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/addons/helm/client_test.go
+++ b/internal/addons/helm/client_test.go
@@ -133,3 +133,37 @@ func TestChartSpec(t *testing.T) {
 		t.Error("ChartSpec fields should not be empty")
 	}
 }
+
+// TestClearCache_NonexistentDir tests ClearCache when cache doesn't exist.
+func TestClearCache_NonexistentDir(t *testing.T) {
+	// Set a non-existent cache path
+	t.Setenv("XDG_CACHE_HOME", "/nonexistent/path/that/does/not/exist")
+
+	// Clear memory cache first
+	ClearMemoryCache()
+
+	// ClearCache should succeed even if directory doesn't exist
+	err := ClearCache()
+	if err != nil {
+		t.Errorf("ClearCache should succeed for nonexistent directory: %v", err)
+	}
+}
+
+// TestClearCache_ClearsMemoryCache verifies memory cache is cleared.
+func TestClearCache_ClearsMemoryCache(t *testing.T) {
+	// Use temp directory for cache
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmpDir)
+
+	// Clear cache should not panic and should clear memory
+	err := ClearCache()
+	if err != nil {
+		t.Errorf("ClearCache failed: %v", err)
+	}
+
+	// Verify we can call it multiple times without error
+	err = ClearCache()
+	if err != nil {
+		t.Errorf("Second ClearCache failed: %v", err)
+	}
+}

--- a/internal/addons/helm/values_test.go
+++ b/internal/addons/helm/values_test.go
@@ -370,6 +370,73 @@ func TestFromYAML_Errors(t *testing.T) {
 	})
 }
 
+func TestConvertToInterface_SliceTypes(t *testing.T) {
+	t.Run("[]Values slice", func(t *testing.T) {
+		input := []Values{
+			{"name": "item1", "value": 1},
+			{"name": "item2", "value": 2},
+		}
+		result := convertToInterface(input)
+
+		arr, ok := result.([]any)
+		require.True(t, ok, "result should be []any")
+		require.Len(t, arr, 2)
+
+		item1, ok := arr[0].(map[string]interface{})
+		require.True(t, ok, "item should be map[string]interface{}")
+		assert.Equal(t, "item1", item1["name"])
+		assert.Equal(t, 1, item1["value"])
+	})
+
+	t.Run("[]map[string]any slice", func(t *testing.T) {
+		input := []map[string]any{
+			{"name": "item1", "value": 1},
+			{"name": "item2", "value": 2},
+		}
+		result := convertToInterface(input)
+
+		arr, ok := result.([]any)
+		require.True(t, ok, "result should be []any")
+		require.Len(t, arr, 2)
+
+		item1, ok := arr[0].(map[string]interface{})
+		require.True(t, ok, "item should be map[string]interface{}")
+		assert.Equal(t, "item1", item1["name"])
+	})
+
+	t.Run("[]string slice", func(t *testing.T) {
+		input := []string{"a", "b", "c"}
+		result := convertToInterface(input)
+
+		arr, ok := result.([]any)
+		require.True(t, ok, "result should be []any")
+		require.Len(t, arr, 3)
+		assert.Equal(t, "a", arr[0])
+		assert.Equal(t, "b", arr[1])
+		assert.Equal(t, "c", arr[2])
+	})
+
+	t.Run("[]int slice", func(t *testing.T) {
+		input := []int{1, 2, 3}
+		result := convertToInterface(input)
+
+		arr, ok := result.([]any)
+		require.True(t, ok, "result should be []any")
+		require.Len(t, arr, 3)
+		assert.Equal(t, 1, arr[0])
+		assert.Equal(t, 2, arr[1])
+		assert.Equal(t, 3, arr[2])
+	})
+
+	t.Run("default case - primitives pass through", func(t *testing.T) {
+		assert.Equal(t, "string", convertToInterface("string"))
+		assert.Equal(t, 42, convertToInterface(42))
+		assert.Equal(t, true, convertToInterface(true))
+		assert.Equal(t, 3.14, convertToInterface(3.14))
+		assert.Nil(t, convertToInterface(nil))
+	})
+}
+
 func TestMergeCustomValues(t *testing.T) {
 	t.Run("nil custom values returns base unchanged", func(t *testing.T) {
 		base := Values{"replicas": 2, "image": "nginx"}


### PR DESCRIPTION
## Summary

- Improve test coverage for `internal/addons/helm` from 62.1% to **88.8%**
- Improve test coverage for `internal/addons/k8sclient` from 54.5% to **89.6%**
- Minor improvement for `cmd/k8zner/handlers` from 56.1% to 57.1%
- Replace custom `contains` helper with `strings.Contains` per CODE_STRUCTURE.md

## Changes

### helm package
- Add `TestConvertToInterface_SliceTypes` for slice type conversion
- Add comprehensive renderer tests (`renderChart` scenarios)
- Add cache path tests with XDG environment variable
- Add cache clearing edge case tests

### handlers package
- Add `TestFormatCNIChoice` for CNI formatting (now 100%)
- Replace custom `contains()`/`containsAt()` with `strings.Contains`

### k8sclient package
- Add tests for multi-document YAML parsing
- Add tests for namespaced and cluster-scoped resources
- Add `NewFromKubeconfig` error path tests
- Add whitespace-only document handling tests

## Test plan

- [x] All tests pass: `go test ./... -short`
- [x] No formatting issues: `gofmt -l .`
- [x] Coverage targets:
  - helm: 88.8% (target >80%) ✓
  - k8sclient: 89.6% (target >80%) ✓
  - handlers: 57.1% (limited by external dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)