### PR TITLE
test(hcloud): improve unit test coverage to 80.6%

### DIFF
--- a/internal/platform/hcloud/cleanup_test.go
+++ b/internal/platform/hcloud/cleanup_test.go
@@ -1,0 +1,461 @@
+package hcloud
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
+)
+
+// TestBuildLabelSelector is already tested in real_client_test.go
+
+func TestGetResourceInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		resource   interface{}
+		expectName string
+		expectID   int64
+	}{
+		{
+			name:       "server",
+			resource:   &hcloud.Server{ID: 1, Name: "server-1"},
+			expectName: "server-1",
+			expectID:   1,
+		},
+		{
+			name:       "load balancer",
+			resource:   &hcloud.LoadBalancer{ID: 2, Name: "lb-1"},
+			expectName: "lb-1",
+			expectID:   2,
+		},
+		{
+			name:       "floating IP",
+			resource:   &hcloud.FloatingIP{ID: 3, Name: "fip-1"},
+			expectName: "fip-1",
+			expectID:   3,
+		},
+		{
+			name:       "firewall",
+			resource:   &hcloud.Firewall{ID: 4, Name: "fw-1"},
+			expectName: "fw-1",
+			expectID:   4,
+		},
+		{
+			name:       "network",
+			resource:   &hcloud.Network{ID: 5, Name: "net-1"},
+			expectName: "net-1",
+			expectID:   5,
+		},
+		{
+			name:       "placement group",
+			resource:   &hcloud.PlacementGroup{ID: 6, Name: "pg-1"},
+			expectName: "pg-1",
+			expectID:   6,
+		},
+		{
+			name:       "SSH key",
+			resource:   &hcloud.SSHKey{ID: 7, Name: "key-1"},
+			expectName: "key-1",
+			expectID:   7,
+		},
+		{
+			name:       "certificate",
+			resource:   &hcloud.Certificate{ID: 8, Name: "cert-1"},
+			expectName: "cert-1",
+			expectID:   8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var info resourceInfo
+			switch v := tt.resource.(type) {
+			case *hcloud.Server:
+				info = getResourceInfo(v)
+			case *hcloud.LoadBalancer:
+				info = getResourceInfo(v)
+			case *hcloud.FloatingIP:
+				info = getResourceInfo(v)
+			case *hcloud.Firewall:
+				info = getResourceInfo(v)
+			case *hcloud.Network:
+				info = getResourceInfo(v)
+			case *hcloud.PlacementGroup:
+				info = getResourceInfo(v)
+			case *hcloud.SSHKey:
+				info = getResourceInfo(v)
+			case *hcloud.Certificate:
+				info = getResourceInfo(v)
+			}
+
+			if info.Name != tt.expectName {
+				t.Errorf("expected name %q, got %q", tt.expectName, info.Name)
+			}
+			if info.ID != tt.expectID {
+				t.Errorf("expected ID %d, got %d", tt.expectID, info.ID)
+			}
+		})
+	}
+}
+
+func TestRealClient_CleanupByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	// Mock all endpoints with empty lists - this tests the happy path with no resources
+	ts.handleFunc("/servers", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.ServerListResponse{Servers: []schema.Server{}})
+	})
+
+	ts.handleFunc("/load_balancers", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.LoadBalancerListResponse{LoadBalancers: []schema.LoadBalancer{}})
+	})
+
+	ts.handleFunc("/floating_ips", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.FloatingIPListResponse{FloatingIPs: []schema.FloatingIP{}})
+	})
+
+	ts.handleFunc("/firewalls", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.FirewallListResponse{Firewalls: []schema.Firewall{}})
+	})
+
+	ts.handleFunc("/networks", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.NetworkListResponse{Networks: []schema.Network{}})
+	})
+
+	ts.handleFunc("/placement_groups", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.PlacementGroupListResponse{PlacementGroups: []schema.PlacementGroup{}})
+	})
+
+	ts.handleFunc("/ssh_keys", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.SSHKeyListResponse{SSHKeys: []schema.SSHKey{}})
+	})
+
+	ts.handleFunc("/certificates", func(w http.ResponseWriter, _ *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.CertificateListResponse{Certificates: []schema.Certificate{}})
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.CleanupByLabel(ctx, map[string]string{"cluster": "test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRealClient_DeleteServersByLabel_WithHTTPMock(t *testing.T) {
+	t.Run("deletes servers successfully", func(t *testing.T) {
+		ts := newTestServer()
+		defer ts.close()
+
+		callCount := 0
+		ts.handleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			// First call returns servers to delete, subsequent calls return empty
+			if callCount == 1 {
+				jsonResponse(w, http.StatusOK, schema.ServerListResponse{
+					Servers: []schema.Server{
+						{ID: 1, Name: "server-1", Labels: map[string]string{"cluster": "test"}},
+						{ID: 2, Name: "server-2", Labels: map[string]string{"cluster": "test"}},
+					},
+				})
+				return
+			}
+			// After first call, return empty (servers deleted)
+			jsonResponse(w, http.StatusOK, schema.ServerListResponse{Servers: []schema.Server{}})
+		})
+
+		ts.handleFunc("/servers/1", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				jsonResponse(w, http.StatusOK, schema.ServerDeleteResponse{
+					Action: schema.Action{ID: 1, Status: "success"},
+				})
+				return
+			}
+		})
+
+		ts.handleFunc("/servers/2", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				jsonResponse(w, http.StatusOK, schema.ServerDeleteResponse{
+					Action: schema.Action{ID: 2, Status: "success"},
+				})
+				return
+			}
+		})
+
+		client := ts.realClient()
+		ctx := context.Background()
+
+		err := client.deleteServersByLabel(ctx, "cluster=test")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("handles empty label selector", func(t *testing.T) {
+		ts := newTestServer()
+		defer ts.close()
+
+		ts.handleFunc("/servers", func(w http.ResponseWriter, _ *http.Request) {
+			jsonResponse(w, http.StatusOK, schema.ServerListResponse{Servers: []schema.Server{}})
+		})
+
+		client := ts.realClient()
+		ctx := context.Background()
+
+		err := client.deleteServersByLabel(ctx, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestRealClient_DeleteLoadBalancersByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	ts.handleFunc("/load_balancers", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.LoadBalancerListResponse{
+			LoadBalancers: []schema.LoadBalancer{
+				{ID: 1, Name: "lb-1", Labels: map[string]string{"cluster": "test"}},
+			},
+		})
+	})
+
+	ts.handleFunc("/load_balancers/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.deleteLoadBalancersByLabel(ctx, "cluster=test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRealClient_DeleteFloatingIPsByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	ts.handleFunc("/floating_ips", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.FloatingIPListResponse{
+			FloatingIPs: []schema.FloatingIP{
+				{ID: 1, Name: "fip-1", Labels: map[string]string{"cluster": "test"}},
+			},
+		})
+	})
+
+	ts.handleFunc("/floating_ips/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.deleteFloatingIPsByLabel(ctx, "cluster=test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRealClient_DeleteFirewallsByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	ts.handleFunc("/firewalls", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.FirewallListResponse{
+			Firewalls: []schema.Firewall{
+				{ID: 1, Name: "fw-1", Labels: map[string]string{"cluster": "test"}},
+			},
+		})
+	})
+
+	ts.handleFunc("/firewalls/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.deleteFirewallsByLabel(ctx, "cluster=test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRealClient_DeleteNetworksByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	ts.handleFunc("/networks", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.NetworkListResponse{
+			Networks: []schema.Network{
+				{ID: 1, Name: "net-1", Labels: map[string]string{"cluster": "test"}},
+			},
+		})
+	})
+
+	ts.handleFunc("/networks/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.deleteNetworksByLabel(ctx, "cluster=test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRealClient_DeletePlacementGroupsByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	ts.handleFunc("/placement_groups", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.PlacementGroupListResponse{
+			PlacementGroups: []schema.PlacementGroup{
+				{ID: 1, Name: "pg-1", Labels: map[string]string{"cluster": "test"}},
+			},
+		})
+	})
+
+	ts.handleFunc("/placement_groups/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.deletePlacementGroupsByLabel(ctx, "cluster=test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRealClient_DeleteSSHKeysByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	ts.handleFunc("/ssh_keys", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.SSHKeyListResponse{
+			SSHKeys: []schema.SSHKey{
+				{ID: 1, Name: "key-1", Labels: map[string]string{"cluster": "test"}},
+			},
+		})
+	})
+
+	ts.handleFunc("/ssh_keys/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.deleteSSHKeysByLabel(ctx, "cluster=test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRealClient_DeleteCertificatesByLabel_WithHTTPMock(t *testing.T) {
+	ts := newTestServer()
+	defer ts.close()
+
+	ts.handleFunc("/certificates", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, http.StatusOK, schema.CertificateListResponse{
+			Certificates: []schema.Certificate{
+				{ID: 1, Name: "cert-1", Labels: map[string]string{"cluster": "test"}},
+			},
+		})
+	})
+
+	ts.handleFunc("/certificates/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	})
+
+	client := ts.realClient()
+	ctx := context.Background()
+
+	err := client.deleteCertificatesByLabel(ctx, "cluster=test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteResourcesByLabel(t *testing.T) {
+	// Test the generic deleteResourcesByLabel function
+	t.Run("handles list error", func(t *testing.T) {
+		ctx := context.Background()
+		err := deleteResourcesByLabel(ctx, "test",
+			func(ctx context.Context) ([]*hcloud.Server, error) {
+				return nil, context.DeadlineExceeded
+			},
+			func(ctx context.Context, s *hcloud.Server) error {
+				return nil
+			},
+		)
+		if err == nil {
+			t.Fatal("expected error from list function")
+		}
+	})
+
+	t.Run("handles delete error gracefully", func(t *testing.T) {
+		ctx := context.Background()
+		// deleteResourcesByLabel should log errors but not return them
+		err := deleteResourcesByLabel(ctx, "test",
+			func(ctx context.Context) ([]*hcloud.Server, error) {
+				return []*hcloud.Server{{ID: 1, Name: "test-server"}}, nil
+			},
+			func(ctx context.Context, s *hcloud.Server) error {
+				return context.DeadlineExceeded
+			},
+		)
+		// Should not return error even if delete fails (just logs warning)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("handles empty list", func(t *testing.T) {
+		ctx := context.Background()
+		err := deleteResourcesByLabel(ctx, "test",
+			func(ctx context.Context) ([]*hcloud.Server, error) {
+				return []*hcloud.Server{}, nil
+			},
+			func(ctx context.Context, s *hcloud.Server) error {
+				t.Error("delete should not be called for empty list")
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/platform/hcloud/mock_client_test.go
+++ b/internal/platform/hcloud/mock_client_test.go
@@ -553,4 +553,478 @@ func TestMockClient_CustomFuncs(t *testing.T) {
 			t.Errorf("expected server ID 100, got %d", servers[0].ID)
 		}
 	})
+
+	t.Run("GetServerIP custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetServerIPFunc: func(_ context.Context, _ string) (string, error) {
+				return "10.0.0.1", nil
+			},
+		}
+		ip, err := m.GetServerIP(ctx, "test")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if ip != "10.0.0.1" {
+			t.Errorf("expected '10.0.0.1', got %q", ip)
+		}
+	})
+
+	t.Run("GetServerID custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetServerIDFunc: func(_ context.Context, _ string) (string, error) {
+				return "999", nil
+			},
+		}
+		id, err := m.GetServerID(ctx, "test")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if id != "999" {
+			t.Errorf("expected '999', got %q", id)
+		}
+	})
+
+	t.Run("EnableRescue custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnableRescueFunc: func(_ context.Context, _ string, _ []string) (string, error) {
+				return "custom-password", nil
+			},
+		}
+		pwd, err := m.EnableRescue(ctx, "123", nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if pwd != "custom-password" {
+			t.Errorf("expected 'custom-password', got %q", pwd)
+		}
+	})
+
+	t.Run("ResetServer custom func", func(t *testing.T) {
+		m := &MockClient{
+			ResetServerFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.ResetServer(ctx, "123")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("PoweroffServer custom func", func(t *testing.T) {
+		m := &MockClient{
+			PoweroffServerFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.PoweroffServer(ctx, "123")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("CreateSnapshot custom func", func(t *testing.T) {
+		m := &MockClient{
+			CreateSnapshotFunc: func(_ context.Context, _, _ string, _ map[string]string) (string, error) {
+				return "custom-snapshot", nil
+			},
+		}
+		id, err := m.CreateSnapshot(ctx, "123", "desc", nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if id != "custom-snapshot" {
+			t.Errorf("expected 'custom-snapshot', got %q", id)
+		}
+	})
+
+	t.Run("DeleteImage custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeleteImageFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeleteImage(ctx, "123")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("GetSnapshotByLabels custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetSnapshotByLabelsFunc: func(_ context.Context, _ map[string]string) (*hcloud.Image, error) {
+				return &hcloud.Image{ID: 42}, nil
+			},
+		}
+		img, err := m.GetSnapshotByLabels(ctx, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if img.ID != 42 {
+			t.Errorf("expected ID 42, got %d", img.ID)
+		}
+	})
+
+	t.Run("CreateSSHKey custom func", func(t *testing.T) {
+		m := &MockClient{
+			CreateSSHKeyFunc: func(_ context.Context, _, _ string, _ map[string]string) (string, error) {
+				return "custom-key", nil
+			},
+		}
+		id, err := m.CreateSSHKey(ctx, "key", "pub", nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if id != "custom-key" {
+			t.Errorf("expected 'custom-key', got %q", id)
+		}
+	})
+
+	t.Run("DeleteSSHKey custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeleteSSHKeyFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeleteSSHKey(ctx, "key")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("EnsureNetwork custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnsureNetworkFunc: func(_ context.Context, _, _, _ string, _ map[string]string) (*hcloud.Network, error) {
+				return &hcloud.Network{ID: 42}, nil
+			},
+		}
+		net, err := m.EnsureNetwork(ctx, "net", "10.0.0.0/8", "eu-central", nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if net.ID != 42 {
+			t.Errorf("expected ID 42, got %d", net.ID)
+		}
+	})
+
+	t.Run("EnsureSubnet custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnsureSubnetFunc: func(_ context.Context, _ *hcloud.Network, _, _ string, _ hcloud.NetworkSubnetType) error {
+				return customErr
+			},
+		}
+		err := m.EnsureSubnet(ctx, nil, "10.0.0.0/24", "eu-central", hcloud.NetworkSubnetTypeCloud)
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("DeleteNetwork custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeleteNetworkFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeleteNetwork(ctx, "net")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("EnsureFirewall custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnsureFirewallFunc: func(_ context.Context, _ string, _ []hcloud.FirewallRule, _ map[string]string, _ string) (*hcloud.Firewall, error) {
+				return &hcloud.Firewall{ID: 42}, nil
+			},
+		}
+		fw, err := m.EnsureFirewall(ctx, "fw", nil, nil, "")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if fw.ID != 42 {
+			t.Errorf("expected ID 42, got %d", fw.ID)
+		}
+	})
+
+	t.Run("DeleteFirewall custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeleteFirewallFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeleteFirewall(ctx, "fw")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("GetFirewall custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetFirewallFunc: func(_ context.Context, _ string) (*hcloud.Firewall, error) {
+				return &hcloud.Firewall{ID: 42}, nil
+			},
+		}
+		fw, err := m.GetFirewall(ctx, "fw")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if fw.ID != 42 {
+			t.Errorf("expected ID 42, got %d", fw.ID)
+		}
+	})
+
+	t.Run("EnsureLoadBalancer custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnsureLoadBalancerFunc: func(_ context.Context, _, _, _ string, _ hcloud.LoadBalancerAlgorithmType, _ map[string]string) (*hcloud.LoadBalancer, error) {
+				return &hcloud.LoadBalancer{ID: 42}, nil
+			},
+		}
+		lb, err := m.EnsureLoadBalancer(ctx, "lb", "fsn1", "lb11", hcloud.LoadBalancerAlgorithmTypeRoundRobin, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if lb.ID != 42 {
+			t.Errorf("expected ID 42, got %d", lb.ID)
+		}
+	})
+
+	t.Run("ConfigureService custom func", func(t *testing.T) {
+		m := &MockClient{
+			ConfigureServiceFunc: func(_ context.Context, _ *hcloud.LoadBalancer, _ hcloud.LoadBalancerAddServiceOpts) error {
+				return customErr
+			},
+		}
+		err := m.ConfigureService(ctx, nil, hcloud.LoadBalancerAddServiceOpts{})
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("AddTarget custom func", func(t *testing.T) {
+		m := &MockClient{
+			AddTargetFunc: func(_ context.Context, _ *hcloud.LoadBalancer, _ hcloud.LoadBalancerTargetType, _ string) error {
+				return customErr
+			},
+		}
+		err := m.AddTarget(ctx, nil, hcloud.LoadBalancerTargetTypeServer, "")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("AttachToNetwork custom func", func(t *testing.T) {
+		m := &MockClient{
+			AttachToNetworkFunc: func(_ context.Context, _ *hcloud.LoadBalancer, _ *hcloud.Network, _ net.IP) error {
+				return customErr
+			},
+		}
+		err := m.AttachToNetwork(ctx, nil, nil, nil)
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("DeleteLoadBalancer custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeleteLoadBalancerFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeleteLoadBalancer(ctx, "lb")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("GetLoadBalancer custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetLoadBalancerFunc: func(_ context.Context, _ string) (*hcloud.LoadBalancer, error) {
+				return &hcloud.LoadBalancer{ID: 42}, nil
+			},
+		}
+		lb, err := m.GetLoadBalancer(ctx, "lb")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if lb.ID != 42 {
+			t.Errorf("expected ID 42, got %d", lb.ID)
+		}
+	})
+
+	t.Run("EnsurePlacementGroup custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnsurePlacementGroupFunc: func(_ context.Context, _, _ string, _ map[string]string) (*hcloud.PlacementGroup, error) {
+				return &hcloud.PlacementGroup{ID: 42}, nil
+			},
+		}
+		pg, err := m.EnsurePlacementGroup(ctx, "pg", "spread", nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if pg.ID != 42 {
+			t.Errorf("expected ID 42, got %d", pg.ID)
+		}
+	})
+
+	t.Run("DeletePlacementGroup custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeletePlacementGroupFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeletePlacementGroup(ctx, "pg")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("GetPlacementGroup custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetPlacementGroupFunc: func(_ context.Context, _ string) (*hcloud.PlacementGroup, error) {
+				return &hcloud.PlacementGroup{ID: 42}, nil
+			},
+		}
+		pg, err := m.GetPlacementGroup(ctx, "pg")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if pg.ID != 42 {
+			t.Errorf("expected ID 42, got %d", pg.ID)
+		}
+	})
+
+	t.Run("EnsureFloatingIP custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnsureFloatingIPFunc: func(_ context.Context, _, _, _ string, _ map[string]string) (*hcloud.FloatingIP, error) {
+				return &hcloud.FloatingIP{ID: 42}, nil
+			},
+		}
+		fip, err := m.EnsureFloatingIP(ctx, "fip", "fsn1", "ipv4", nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if fip.ID != 42 {
+			t.Errorf("expected ID 42, got %d", fip.ID)
+		}
+	})
+
+	t.Run("DeleteFloatingIP custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeleteFloatingIPFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeleteFloatingIP(ctx, "fip")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("GetFloatingIP custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetFloatingIPFunc: func(_ context.Context, _ string) (*hcloud.FloatingIP, error) {
+				return &hcloud.FloatingIP{ID: 42}, nil
+			},
+		}
+		fip, err := m.GetFloatingIP(ctx, "fip")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if fip.ID != 42 {
+			t.Errorf("expected ID 42, got %d", fip.ID)
+		}
+	})
+
+	t.Run("EnsureCertificate custom func", func(t *testing.T) {
+		m := &MockClient{
+			EnsureCertificateFunc: func(_ context.Context, _, _, _ string, _ map[string]string) (*hcloud.Certificate, error) {
+				return &hcloud.Certificate{ID: 42}, nil
+			},
+		}
+		cert, err := m.EnsureCertificate(ctx, "cert", "data", "key", nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if cert.ID != 42 {
+			t.Errorf("expected ID 42, got %d", cert.ID)
+		}
+	})
+
+	t.Run("GetCertificate custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetCertificateFunc: func(_ context.Context, _ string) (*hcloud.Certificate, error) {
+				return &hcloud.Certificate{ID: 42}, nil
+			},
+		}
+		cert, err := m.GetCertificate(ctx, "cert")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if cert.ID != 42 {
+			t.Errorf("expected ID 42, got %d", cert.ID)
+		}
+	})
+
+	t.Run("DeleteCertificate custom func", func(t *testing.T) {
+		m := &MockClient{
+			DeleteCertificateFunc: func(_ context.Context, _ string) error {
+				return customErr
+			},
+		}
+		err := m.DeleteCertificate(ctx, "cert")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("SetServerRDNS custom func", func(t *testing.T) {
+		m := &MockClient{
+			SetServerRDNSFunc: func(_ context.Context, _ int64, _, _ string) error {
+				return customErr
+			},
+		}
+		err := m.SetServerRDNS(ctx, 123, "1.2.3.4", "example.com")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("SetLoadBalancerRDNS custom func", func(t *testing.T) {
+		m := &MockClient{
+			SetLoadBalancerRDNSFunc: func(_ context.Context, _ int64, _, _ string) error {
+				return customErr
+			},
+		}
+		err := m.SetLoadBalancerRDNS(ctx, 123, "1.2.3.4", "example.com")
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
+
+	t.Run("GetPublicIP custom func", func(t *testing.T) {
+		m := &MockClient{
+			GetPublicIPFunc: func(_ context.Context) (string, error) {
+				return "10.0.0.1", nil
+			},
+		}
+		ip, err := m.GetPublicIP(ctx)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if ip != "10.0.0.1" {
+			t.Errorf("expected '10.0.0.1', got %q", ip)
+		}
+	})
+
+	t.Run("CleanupByLabel custom func", func(t *testing.T) {
+		m := &MockClient{
+			CleanupByLabelFunc: func(_ context.Context, _ map[string]string) error {
+				return customErr
+			},
+		}
+		err := m.CleanupByLabel(ctx, map[string]string{"key": "value"})
+		if !errors.Is(err, customErr) {
+			t.Errorf("expected custom error, got %v", err)
+		}
+	})
 }

--- a/internal/platform/hcloud/server_helpers_test.go
+++ b/internal/platform/hcloud/server_helpers_test.go
@@ -1,0 +1,182 @@
+package hcloud
+
+import (
+	"net"
+	"testing"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func TestServerIPv4(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   *hcloud.Server
+		expected string
+	}{
+		{
+			name:     "nil server",
+			server:   nil,
+			expected: "",
+		},
+		{
+			name: "server with IPv4",
+			server: &hcloud.Server{
+				PublicNet: hcloud.ServerPublicNet{
+					IPv4: hcloud.ServerPublicNetIPv4{
+						IP: net.ParseIP("203.0.113.42"),
+					},
+				},
+			},
+			expected: "203.0.113.42",
+		},
+		{
+			name: "server without IPv4",
+			server: &hcloud.Server{
+				PublicNet: hcloud.ServerPublicNet{
+					IPv4: hcloud.ServerPublicNetIPv4{},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ServerIPv4(tt.server)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestServerIPv6(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   *hcloud.Server
+		expected string
+	}{
+		{
+			name:     "nil server",
+			server:   nil,
+			expected: "",
+		},
+		{
+			name: "server with IPv6",
+			server: &hcloud.Server{
+				PublicNet: hcloud.ServerPublicNet{
+					IPv6: hcloud.ServerPublicNetIPv6{
+						IP: net.ParseIP("2001:db8::1"),
+					},
+				},
+			},
+			expected: "2001:db8::1",
+		},
+		{
+			name: "server without IPv6",
+			server: &hcloud.Server{
+				PublicNet: hcloud.ServerPublicNet{
+					IPv6: hcloud.ServerPublicNetIPv6{},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ServerIPv6(tt.server)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestLoadBalancerIPv4(t *testing.T) {
+	tests := []struct {
+		name     string
+		lb       *hcloud.LoadBalancer
+		expected string
+	}{
+		{
+			name:     "nil load balancer",
+			lb:       nil,
+			expected: "",
+		},
+		{
+			name: "load balancer with IPv4",
+			lb: &hcloud.LoadBalancer{
+				PublicNet: hcloud.LoadBalancerPublicNet{
+					IPv4: hcloud.LoadBalancerPublicNetIPv4{
+						IP: net.ParseIP("203.0.113.100"),
+					},
+				},
+			},
+			expected: "203.0.113.100",
+		},
+		{
+			name: "load balancer without IPv4",
+			lb: &hcloud.LoadBalancer{
+				PublicNet: hcloud.LoadBalancerPublicNet{
+					IPv4: hcloud.LoadBalancerPublicNetIPv4{},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := LoadBalancerIPv4(tt.lb)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestLoadBalancerIPv6(t *testing.T) {
+	tests := []struct {
+		name     string
+		lb       *hcloud.LoadBalancer
+		expected string
+	}{
+		{
+			name:     "nil load balancer",
+			lb:       nil,
+			expected: "",
+		},
+		{
+			name: "load balancer with IPv6",
+			lb: &hcloud.LoadBalancer{
+				PublicNet: hcloud.LoadBalancerPublicNet{
+					IPv6: hcloud.LoadBalancerPublicNetIPv6{
+						IP: net.ParseIP("2001:db8::100"),
+					},
+				},
+			},
+			expected: "2001:db8::100",
+		},
+		{
+			name: "load balancer without IPv6",
+			lb: &hcloud.LoadBalancer{
+				PublicNet: hcloud.LoadBalancerPublicNet{
+					IPv6: hcloud.LoadBalancerPublicNetIPv6{},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := LoadBalancerIPv6(tt.lb)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestResolvePlacementGroup is already tested in real_client_test.go


### PR DESCRIPTION
## Summary

- Add comprehensive HTTP-mocked tests for all Hetzner Cloud API operations
- Add mock client custom function tests for complete MockClient coverage
- Create new test files: `cleanup_test.go`, `server_helpers_test.go`
- Extend `http_test.go` with 1291 lines of new tests
- Coverage increased from 33.2% to 80.6% (target: >80%)

### Test Coverage by Area

| Component | Tests Added |
|-----------|-------------|
| Firewall | EnsureFirewall (create, update, label matching) |
| Load Balancer | EnsureLoadBalancer, ConfigureService, AddTarget, Delete |
| Floating IP | EnsureFloatingIP, DeleteFloatingIP |
| Certificate | EnsureCertificate, DeleteCertificate |
| Snapshot | CreateSnapshot, DeleteImage |
| RDNS | SetServerRDNS, SetLoadBalancerRDNS (validation) |
| Network | EnsureNetwork, EnsureSubnet, AttachToNetwork |
| Server | CreateServer (all options), EnableRescue, ResetServer, PoweroffServer |
| Cleanup | CleanupByLabel, delete*ByLabel for all resource types |
| Helpers | ServerIPv4/IPv6, LoadBalancerIPv4/IPv6, getResourceInfo |
| MockClient | All custom function paths |

## Test plan

- [x] All existing tests pass
- [x] New tests pass with 80.6% coverage
- [x] No linting issues (`golangci-lint run`)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)