### PR TITLE
feat: implement E2E tests for operator self-healing

### DIFF
--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -18,6 +18,7 @@ type E2EConfig struct {
 	SkipAddonsAdvanced bool
 	SkipMonitoring     bool
 	SkipScale          bool
+	SkipSelfHealing    bool
 	SkipUpgrade        bool
 
 	// Cluster reuse
@@ -48,6 +49,7 @@ func LoadE2EConfig() *E2EConfig {
 		SkipAddonsAdvanced: getEnvBool("E2E_SKIP_ADDONS_ADVANCED"),
 		SkipMonitoring:     getEnvBool("E2E_SKIP_MONITORING"),
 		SkipScale:          getEnvBool("E2E_SKIP_SCALE"),
+		SkipSelfHealing:    getEnvBool("E2E_SKIP_SELF_HEALING"),
 		SkipUpgrade:        getEnvBool("E2E_SKIP_UPGRADE"),
 
 		// Cluster reuse
@@ -100,6 +102,9 @@ func (c *E2EConfig) RunPhases() []string {
 	}
 	if !c.SkipScale {
 		phases = append(phases, "scale")
+	}
+	if !c.SkipSelfHealing {
+		phases = append(phases, "self-healing")
 	}
 	if !c.SkipUpgrade {
 		phases = append(phases, "upgrade")


### PR DESCRIPTION
## Summary
- Add `SkipSelfHealing` config option for E2E test control via `E2E_SKIP_SELF_HEALING` env var
- Update `phaseSelfHealing` to deploy k8zner-operator addon and test actual self-healing
- Create K8znerCluster CRD resource for existing cluster during tests
- Add `TestE2ESelfHealingHA` standalone E2E test function

## Self-Healing E2E Test Flow
1. Deploys the k8zner-operator to the cluster (using `main` image tag)
2. Creates a K8znerCluster CRD pointing to existing cluster nodes
3. Powers off a worker node to simulate failure
4. Waits for operator to:
   - Detect unhealthy node (phase → Degraded)
   - Replace the node (phase → Healing)
   - Restore cluster health (phase → Running)
5. Verifies node count is restored and cluster is functional

## Test Plan
- [x] Unit tests pass (`go test ./internal/... ./cmd/...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Kind tests compile (`go test -tags=kind -run=NonExistent ./tests/kind/...`)
- [x] E2E tests compile (`go test -tags=e2e -run=NonExistent ./tests/e2e/...`)
- [ ] CI checks pass

## Running Self-Healing E2E Test
```bash
# Run as part of full E2E suite
HCLOUD_TOKEN=xxx go test -v -timeout=60m -tags=e2e -run TestE2EHACluster ./tests/e2e/...

# Run standalone self-healing test
HCLOUD_TOKEN=xxx go test -v -timeout=60m -tags=e2e -run TestE2ESelfHealingHA ./tests/e2e/...

# Skip self-healing in E2E suite
E2E_SKIP_SELF_HEALING=true HCLOUD_TOKEN=xxx go test -v -timeout=60m -tags=e2e ./tests/e2e/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)