### PR TITLE
fix: operator scheduling and E2E test file structure

### DIFF
--- a/internal/addons/operator.go
+++ b/internal/addons/operator.go
@@ -167,6 +167,10 @@ func buildOperatorValues(cfg *config.Config) helm.Values {
 				"memory": "128Mi",
 			},
 		},
+		// Override nodeSelector to allow scheduling on any node
+		// Talos nodes may not have the control-plane label set
+		"nodeSelector": helm.Values{},
+		"tolerations":  []interface{}{},
 	}
 
 	// Enable ServiceMonitor if monitoring is enabled

--- a/tests/e2e/phase_selfhealing.go
+++ b/tests/e2e/phase_selfhealing.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/imamik/k8zner/internal/addons"
 	"github.com/imamik/k8zner/internal/config"
-	"github.com/imamik/k8zner/internal/platform/hcloud"
 )
 
 // phaseSelfHealing tests the self-healing mechanism using the k8zner-operator.
@@ -478,49 +477,4 @@ spec:
 	_ = cleanupCmd.Run()
 
 	return nil
-}
-
-// TestE2ESelfHealingHA is a dedicated E2E test for self-healing on HA clusters.
-// This test requires an HA cluster (3 CPs, 2+ workers) and tests:
-// - Worker node failure and automatic replacement
-// - (Future) Control plane node failure and replacement with quorum preservation
-//
-// Run with: HCLOUD_TOKEN=xxx go test -v -timeout=60m -tags=e2e -run TestE2ESelfHealingHA ./tests/e2e/...
-func TestE2ESelfHealingHA(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping self-healing test in short mode")
-	}
-
-	token := os.Getenv("HCLOUD_TOKEN")
-	if token == "" {
-		t.Skip("HCLOUD_TOKEN not set, skipping E2E test")
-	}
-
-	clusterName := fmt.Sprintf("e2e-selfheal-%d", time.Now().Unix())
-	t.Logf("=== Starting Self-Healing HA E2E Test: %s ===", clusterName)
-
-	client := hcloud.NewRealClient(token)
-	state := NewE2EState(clusterName, client)
-	defer cleanupE2ECluster(t, state)
-
-	// === PHASE 1: DEPLOY HA CLUSTER ===
-	t.Log("=== DEPLOYMENT PHASE ===")
-
-	// Get snapshot
-	deployGetSnapshot(t, state)
-
-	// Deploy HA cluster
-	cfg := deployHACluster(t, state, token)
-
-	// Install addons
-	deployAllAddons(t, state, cfg, token)
-
-	t.Log("=== DEPLOYMENT COMPLETE ===")
-
-	// === PHASE 2: SELF-HEALING TEST ===
-	t.Log("=== SELF-HEALING TEST PHASE ===")
-
-	phaseSelfHealing(t, state)
-
-	t.Log("=== SELF-HEALING HA E2E TEST PASSED ===")
 }

--- a/tests/e2e/selfhealing_test.go
+++ b/tests/e2e/selfhealing_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/imamik/k8zner/internal/platform/hcloud"
+)
+
+// TestE2ESelfHealingHA is a dedicated E2E test for self-healing on HA clusters.
+// This test requires an HA cluster (3 CPs, 2+ workers) and tests:
+// - Worker node failure and automatic replacement
+// - (Future) Control plane node failure and replacement with quorum preservation
+//
+// Run with: HCLOUD_TOKEN=xxx go test -v -timeout=60m -tags=e2e -run TestE2ESelfHealingHA ./tests/e2e/...
+func TestE2ESelfHealingHA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping self-healing test in short mode")
+	}
+
+	token := os.Getenv("HCLOUD_TOKEN")
+	if token == "" {
+		t.Skip("HCLOUD_TOKEN not set, skipping E2E test")
+	}
+
+	clusterName := fmt.Sprintf("e2e-selfheal-%d", time.Now().Unix())
+	t.Logf("=== Starting Self-Healing HA E2E Test: %s ===", clusterName)
+
+	client := hcloud.NewRealClient(token)
+	state := NewE2EState(clusterName, client)
+	defer cleanupE2ECluster(t, state)
+
+	// === PHASE 1: DEPLOY HA CLUSTER ===
+	t.Log("=== DEPLOYMENT PHASE ===")
+
+	// Get snapshot
+	deployGetSnapshot(t, state)
+
+	// Deploy HA cluster
+	cfg := deployHACluster(t, state, token)
+
+	// Install addons
+	deployAllAddons(t, state, cfg, token)
+
+	t.Log("=== DEPLOYMENT COMPLETE ===")
+
+	// === PHASE 2: SELF-HEALING TEST ===
+	t.Log("=== SELF-HEALING TEST PHASE ===")
+
+	phaseSelfHealing(t, state)
+
+	t.Log("=== SELF-HEALING HA E2E TEST PASSED ===")
+}


### PR DESCRIPTION
## Summary
- Fix operator pod scheduling by overriding nodeSelector to allow any node
- Move test function to proper `_test.go` file for Go test discovery
- Clean up duplicate code and unused imports

## Issue
The operator was not being deployed because:
1. Default helm values had `nodeSelector: node-role.kubernetes.io/control-plane: ""` 
2. Talos control plane nodes may not have this exact label
3. The test function was in `phase_selfhealing.go` (not `_test.go`), so Go test discovery didn't find it

## Changes
- `internal/addons/operator.go`: Override nodeSelector and tolerations to empty values
- `tests/e2e/selfhealing_test.go`: New file with `TestE2ESelfHealingHA` function
- `tests/e2e/phase_selfhealing.go`: Remove duplicate test function and unused import

## Test Plan
- [x] Build passes
- [ ] CI passes
- [ ] Re-run E2E self-healing test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)