### PR TITLE
fix: operator deployment scheduling and namespace issues

### DIFF
--- a/internal/addons/operator-chart/templates/deployment.yaml
+++ b/internal/addons/operator-chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "k8zner-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8zner-operator.labels" . | nindent 4 }}
 spec:

--- a/internal/addons/operator-chart/templates/rbac.yaml
+++ b/internal/addons/operator-chart/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "k8zner-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8zner-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/internal/addons/operator-chart/templates/secret.yaml
+++ b/internal/addons/operator-chart/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "k8zner-operator.fullname" . }}-credentials
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8zner-operator.labels" . | nindent 4 }}
 type: Opaque

--- a/internal/addons/operator-chart/templates/service.yaml
+++ b/internal/addons/operator-chart/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "k8zner-operator.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8zner-operator.labels" . | nindent 4 }}
 spec:

--- a/internal/addons/operator-chart/templates/servicemonitor.yaml
+++ b/internal/addons/operator-chart/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "k8zner-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8zner-operator.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}

--- a/internal/addons/operator.go
+++ b/internal/addons/operator.go
@@ -167,10 +167,10 @@ func buildOperatorValues(cfg *config.Config) helm.Values {
 				"memory": "128Mi",
 			},
 		},
-		// Override nodeSelector to allow scheduling on any node
-		// Talos nodes may not have the control-plane label set
-		"nodeSelector": helm.Values{},
-		"tolerations":  []interface{}{},
+		// Use chart defaults for nodeSelector and tolerations:
+		// - nodeSelector: node-role.kubernetes.io/control-plane: ""
+		// - tolerations: control-plane NoSchedule taint
+		// Talos control plane nodes have both the label and taint
 	}
 
 	// Enable ServiceMonitor if monitoring is enabled


### PR DESCRIPTION
## Summary
- Fixed operator pod scheduling failures on control plane nodes
- Fixed resources being deployed to wrong namespace (default instead of k8zner-system)

## Root Causes

### 1. Tolerations Override Issue
The `buildOperatorValues()` function was setting:
```go
"tolerations": []interface{}{}
```
This overrode the chart's default tolerations, causing pods to fail scheduling with:
> 3 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }

### 2. Missing Namespace in Templates
Helm templates didn't include explicit namespace, causing k8sclient to default to "default" namespace when applying manifests.

## Changes
- Removed `nodeSelector` and `tolerations` overrides to use chart defaults
- Added `namespace: {{ .Release.Namespace }}` to all namespaced resources

## Test plan
- [ ] Run E2E self-healing test to verify operator deploys correctly
- [ ] Verify operator pods scheduled on control plane nodes
- [ ] Verify all resources in k8zner-system namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)