### PR TITLE
fix: normalize server types in operator controller

### DIFF
--- a/internal/operator/controller/cluster_controller_test.go
+++ b/internal/operator/controller/cluster_controller_test.go
@@ -768,7 +768,7 @@ func TestSelfHealingControlPlaneReplacement(t *testing.T) {
 		// Verify new server was created
 		assert.Len(t, mockHCloud.CreateServerCalls, 1)
 		createCall := mockHCloud.CreateServerCalls[0]
-		assert.Equal(t, "cx22", createCall.ServerType)
+		assert.Equal(t, "cx23", createCall.ServerType) // cx22 normalized to cx23
 		assert.Equal(t, "nbg1", createCall.Location)
 		assert.Equal(t, "control-plane", createCall.Labels["role"])
 
@@ -1002,7 +1002,7 @@ func TestSelfHealingWorkerReplacement(t *testing.T) {
 		// Verify new server was created with correct type
 		assert.Len(t, mockHCloud.CreateServerCalls, 1)
 		createCall := mockHCloud.CreateServerCalls[0]
-		assert.Equal(t, "cx32", createCall.ServerType) // Worker size
+		assert.Equal(t, "cx33", createCall.ServerType) // Worker size (cx32 normalized to cx33)
 		assert.Equal(t, "nbg1", createCall.Location)
 		assert.Equal(t, "worker", createCall.Labels["role"])
 		assert.Equal(t, "workers", createCall.Labels["pool"])
@@ -1265,7 +1265,7 @@ func TestScaleUpWorkers(t *testing.T) {
 
 		// Verify first server has correct naming (index 2, since 1 exists)
 		assert.Equal(t, "test-cluster-workers-2", mockHCloud.CreateServerCalls[0].Name)
-		assert.Equal(t, "cx22", mockHCloud.CreateServerCalls[0].ServerType)
+		assert.Equal(t, "cx23", mockHCloud.CreateServerCalls[0].ServerType) // cx22 normalized to cx23
 		assert.Equal(t, "nbg1", mockHCloud.CreateServerCalls[0].Location)
 		assert.Equal(t, "worker", mockHCloud.CreateServerCalls[0].Labels["role"])
 


### PR DESCRIPTION
## Summary
- Fix server creation failures due to Hetzner Cloud server type renaming (cx22 → cx23 in 2024)
- Add `normalizeServerSize()` helper that converts legacy server type names to current names
- Update all server creation paths (scale up, replace control plane, replace worker) to normalize server types

## Problem
The E2E self-healing test was failing because the operator was trying to create servers with server type "cx22", which Hetzner Cloud renamed to "cx23" in 2024. The HCloud API returns "server type not found: cx22".

## Solution
Import the config v2 package and use `configv2.ServerSize.Normalize()` to convert legacy server types to their current names before passing them to the HCloud client.

## Test plan
- [x] Unit tests pass
- [x] Linting passes
- [x] Build succeeds
- [ ] E2E self-healing test with real infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)