### PR TITLE
feat: improve E2E tests with cpx22 default, CRD validation fix, and diagnostics

### DIFF
--- a/internal/platform/hcloud/architecture.go
+++ b/internal/platform/hcloud/architecture.go
@@ -27,7 +27,7 @@ func DetectArchitecture(serverType string) Architecture {
 
 // GetDefaultServerType returns a default server type for the given architecture.
 // These are used for image building and must have disk sizes compatible with
-// production server types (e.g., cx23 has 40GB disk).
+// production server types (e.g., cpx22 has 40GB disk).
 //
 // For production, users should explicitly specify appropriate server types
 // based on their workload requirements.
@@ -36,7 +36,7 @@ func GetDefaultServerType(arch Architecture) string {
 	case ArchARM64:
 		return "cax11" // 2 ARM cores, 4 GB RAM, 40 GB disk
 	default:
-		return "cx23" // 2 AMD cores, 4 GB RAM, 40 GB disk
+		return "cpx22" // 2 shared AMD cores, 4 GB RAM, 40 GB disk - better availability than cx23
 	}
 }
 

--- a/internal/platform/hcloud/architecture_test.go
+++ b/internal/platform/hcloud/architecture_test.go
@@ -50,9 +50,9 @@ func TestGetDefaultServerType(t *testing.T) {
 		arch     Architecture
 		expected string
 	}{
-		{ArchAMD64, "cx23"},
+		{ArchAMD64, "cpx22"},
 		{ArchARM64, "cax11"},
-		{"unknown", "cx23"}, // Unknown defaults to AMD64 server type
+		{"unknown", "cpx22"}, // Unknown defaults to AMD64 server type
 	}
 
 	for _, tt := range tests {

--- a/internal/provisioning/image/builder_test.go
+++ b/internal/provisioning/image/builder_test.go
@@ -160,7 +160,7 @@ func TestBuild_DefaultServerType(t *testing.T) {
 		arch               string
 		expectedServerType string
 	}{
-		{"amd64 default", "amd64", "cx23"},
+		{"amd64 default", "amd64", "cpx22"},
 		{"arm64 default", "arm64", "cax11"},
 	}
 

--- a/tests/e2e/phase_snapshots.go
+++ b/tests/e2e/phase_snapshots.go
@@ -126,7 +126,7 @@ func createVerificationSSHKey(ctx context.Context, t *testing.T, state *E2EState
 func verifySnapshot(ctx context.Context, t *testing.T, state *E2EState, arch, snapshotID, sshKeyName string) {
 	serverName := fmt.Sprintf("%s-verify-%s-%d", state.ClusterName, arch, time.Now().Unix())
 
-	serverType := "cx23" // Must match disk size of image builder server
+	serverType := "cpx22" // Must match disk size of image builder server - better availability than cx23
 	if arch == "arm64" {
 		serverType = "cax11"
 	}


### PR DESCRIPTION
## Summary

- Change default server type from cx23 to cpx22 for better availability across Hetzner locations (shared vCPU has more capacity)
- Fix operator CRD validation in `phase_operator_scale.go` by adding required fields
- Add comprehensive diagnostic helpers for better failure analysis in E2E tests

## Changes

### 1. Default Server Type (cpx22)
- Updated `GetDefaultServerType()` in `architecture.go` to return `cpx22` for AMD64
- Updated related tests in `architecture_test.go` and `builder_test.go`
- Updated hardcoded `cx23` in `phase_snapshots.go`

### 2. Operator CRD Validation Fix
- Create credentials Secret before K8znerCluster CRD
- Add required `credentialsRef` field pointing to the Secret
- Add required `kubernetes.version` and `talos.version` fields from version matrix
- Update cleanup to also delete the credentials Secret

### 3. Enhanced Failure Diagnostics
- Add `gatherKubernetesDiagnostics()` helper for comprehensive failure analysis
- Add `gatherConnectivityDiagnostics()` for TCP connectivity checks (ports 6443, 50000)
- Enhance `waitForPod()` with node info on timeout and 30s progress logging
- Enhance `waitForDaemonSet()` with full diagnostics on timeout

## Test plan

- [x] `gofmt -l .` - no formatting issues
- [x] `golangci-lint run ./...` - no lint errors  
- [x] `go test ./...` - all unit tests pass
- [x] `go build ./...` - successful build
- [ ] CI passes
- [ ] E2E tests pass with improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)