### PR TITLE
feat: implement private-first architecture with LB-only entry point

### DIFF
--- a/internal/operator/controller/cluster_controller.go
+++ b/internal/operator/controller/cluster_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/imamik/k8zner/internal/platform/hcloud"
 	"github.com/imamik/k8zner/internal/provisioning"
 	"github.com/imamik/k8zner/internal/util/keygen"
+	"github.com/imamik/k8zner/internal/util/labels"
 	"github.com/imamik/k8zner/internal/util/naming"
 )
 
@@ -1731,11 +1732,11 @@ func (r *ClusterReconciler) scaleUpWorkers(ctx context.Context, cluster *k8znerv
 		// Generate a unique server name with random ID
 		newServerName := naming.Worker(cluster.Name)
 
-		serverLabels := map[string]string{
-			"cluster": cluster.Name,
-			"role":    "worker",
-			"pool":    "workers",
-		}
+		serverLabels := labels.NewLabelBuilder(cluster.Name).
+			WithRole("worker").
+			WithPool("workers").
+			WithManagedBy(labels.ManagedByOperator).
+			Build()
 
 		serverType := normalizeServerSize(cluster.Spec.Workers.Size)
 		logger.Info("creating new worker server",
@@ -2321,11 +2322,11 @@ func (r *ClusterReconciler) replaceControlPlane(ctx context.Context, cluster *k8
 
 	// Step 6: Create new server
 	newServerName := r.generateReplacementServerName(cluster, "control-plane", node.Name)
-	serverLabels := map[string]string{
-		"cluster": cluster.Name,
-		"role":    "control-plane",
-		"pool":    "control-plane",
-	}
+	serverLabels := labels.NewLabelBuilder(cluster.Name).
+		WithRole("control-plane").
+		WithPool("control-plane").
+		WithManagedBy(labels.ManagedByOperator).
+		Build()
 
 	// Track new node phase: CreatingServer
 	r.updateNodePhase(ctx, cluster, "control-plane", NodeStatusUpdate{
@@ -2708,11 +2709,11 @@ func (r *ClusterReconciler) replaceWorker(ctx context.Context, cluster *k8znerv1
 
 	// Step 7: Create new server
 	newServerName := r.generateReplacementServerName(cluster, "worker", node.Name)
-	serverLabels := map[string]string{
-		"cluster": cluster.Name,
-		"role":    "worker",
-		"pool":    "workers",
-	}
+	serverLabels := labels.NewLabelBuilder(cluster.Name).
+		WithRole("worker").
+		WithPool("workers").
+		WithManagedBy(labels.ManagedByOperator).
+		Build()
 
 	// Track new node phase: CreatingServer
 	r.updateNodePhase(ctx, cluster, "worker", NodeStatusUpdate{

--- a/internal/provisioning/compute/control_plane.go
+++ b/internal/provisioning/compute/control_plane.go
@@ -74,6 +74,8 @@ func (p *Provisioner) ProvisionControlPlane(ctx *provisioning.Context) error {
 			PoolIndex:        i,
 			RDNSIPv4:         rdnsIPv4,
 			RDNSIPv6:         rdnsIPv6,
+			EnablePublicIPv4: ctx.Config.ShouldEnablePublicIPv4(),
+			EnablePublicIPv6: ctx.Config.ShouldEnablePublicIPv6(),
 		})
 		if err != nil {
 			return fmt.Errorf("failed to reconcile node pool %s: %w", pool.Name, err)

--- a/internal/provisioning/compute/pool.go
+++ b/internal/provisioning/compute/pool.go
@@ -27,6 +27,8 @@ type NodePoolSpec struct {
 	PoolIndex        int
 	RDNSIPv4         string // RDNS template for IPv4
 	RDNSIPv6         string // RDNS template for IPv6
+	EnablePublicIPv4 bool   // Enable public IPv4 (set from config.ShouldEnablePublicIPv4())
+	EnablePublicIPv6 bool   // Enable public IPv6 (set from config.ShouldEnablePublicIPv6())
 }
 
 // NodePoolResult holds the results of provisioning a node pool.
@@ -141,18 +143,20 @@ func (p *Provisioner) reconcileNodePool(ctx *provisioning.Context, spec NodePool
 			Name: fmt.Sprintf("server-%s", cfg.name),
 			Func: func(_ context.Context) error {
 				info, err := p.ensureServer(ctx, ServerSpec{
-					Name:           cfg.name,
-					Type:           spec.ServerType,
-					Location:       spec.Location,
-					Image:          spec.Image,
-					Role:           spec.Role,
-					Pool:           spec.Name,
-					ExtraLabels:    spec.ExtraLabels,
-					UserData:       spec.UserData,
-					PlacementGroup: cfg.pgID,
-					PrivateIP:      cfg.privateIP,
-					RDNSIPv4:       spec.RDNSIPv4,
-					RDNSIPv6:       spec.RDNSIPv6,
+					Name:             cfg.name,
+					Type:             spec.ServerType,
+					Location:         spec.Location,
+					Image:            spec.Image,
+					Role:             spec.Role,
+					Pool:             spec.Name,
+					ExtraLabels:      spec.ExtraLabels,
+					UserData:         spec.UserData,
+					PlacementGroup:   cfg.pgID,
+					PrivateIP:        cfg.privateIP,
+					RDNSIPv4:         spec.RDNSIPv4,
+					RDNSIPv6:         spec.RDNSIPv6,
+					EnablePublicIPv4: spec.EnablePublicIPv4,
+					EnablePublicIPv6: spec.EnablePublicIPv6,
 				})
 				if err != nil {
 					return err

--- a/internal/provisioning/compute/workers.go
+++ b/internal/provisioning/compute/workers.go
@@ -50,6 +50,8 @@ func (p *Provisioner) ProvisionWorkers(ctx *provisioning.Context) error {
 					PoolIndex:        poolIndex,
 					RDNSIPv4:         rdnsIPv4,
 					RDNSIPv6:         rdnsIPv6,
+					EnablePublicIPv4: ctx.Config.ShouldEnablePublicIPv4(),
+					EnablePublicIPv6: ctx.Config.ShouldEnablePublicIPv6(),
 				})
 				if err != nil {
 					return err

--- a/tests/e2e/operator_helpers.go
+++ b/tests/e2e/operator_helpers.go
@@ -507,7 +507,11 @@ func VerifyClusterCleanup(ctx context.Context, t *testing.T, state *OperatorTest
 }
 
 // GetClusterStatus fetches the K8znerCluster CRD.
+// Returns nil if state or K8sClient is nil (e.g., cluster creation failed).
 func GetClusterStatus(ctx context.Context, state *OperatorTestContext) *k8znerv1alpha1.K8znerCluster {
+	if state == nil || state.K8sClient == nil {
+		return nil
+	}
 	cluster := &k8znerv1alpha1.K8znerCluster{}
 	key := client.ObjectKey{
 		Namespace: "k8zner-system",


### PR DESCRIPTION
## Summary
- Implements opinionated private-first architecture where LB is the **only** IPv4 entry point
- Servers get no public IPv4 (only IPv6 + private IPv4)
- All Talos API communication goes through LB:50000
- All kubectl access goes through LB:6443

## Changes

### Private-First Architecture
- Add `IsPrivateFirst()`, `ShouldEnablePublicIPv4()`, `ShouldEnablePublicIPv6()` config helpers
- Add Talos API service (port 50000) to kube-api Load Balancer
- Update server creation to disable public IPv4 when `cluster_access: private`
- Implement LB-only bootstrap flow with sequential config application and retry logic

### P0 Cleanup Fixes
- Add `DeleteCCMLoadBalancers()` for cleaning up CCM-created LBs (fixes orphaned LBs)
- Add `RemoveResources` call before firewall deletion (fixes firewall stuck in resource_in_use)
- Fix operator server labeling with `LabelBuilder` (fixes workers not cleaned up)
- Add nil check in `GetClusterStatus` (fixes panic when kubeconfig is nil)

## Test plan
- [ ] Run E2E tests to verify cleanup fixes
- [ ] Test private-first mode with `cluster_access: private`
- [ ] Verify LB-only bootstrap works for dev mode (1 CP)
- [ ] Verify HA mode bootstrap via LB (3 CPs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)