### PR TITLE
fix: pass NodeIPv4CIDR through CRD to fix CCM subnet discovery

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -83,6 +83,12 @@ type NetworkSpec struct {
 	// +optional
 	IPv4CIDR string `json:"ipv4CIDR,omitempty"`
 
+	// NodeIPv4CIDR is the CIDR range for node IPs within the private network.
+	// This is used to calculate subnets for control planes, load balancers, and workers.
+	// If not set, defaults to "10.0.0.0/17" (lower half of the network CIDR).
+	// +optional
+	NodeIPv4CIDR string `json:"nodeIPv4CIDR,omitempty"`
+
 	// PodCIDR is the CIDR range for pod IPs
 	// +kubebuilder:default="10.244.0.0/16"
 	// +optional

--- a/cmd/k8zner/handlers/create.go
+++ b/cmd/k8zner/handlers/create.go
@@ -416,9 +416,10 @@ func buildK8znerClusterForCreate(cfg *config.Config, _ *provisioning.Context, in
 				Size:  getWorkerSize(cfg),
 			},
 			Network: k8znerv1alpha1.NetworkSpec{
-				IPv4CIDR:    cfg.Network.IPv4CIDR,
-				PodCIDR:     cfg.Network.PodIPv4CIDR,
-				ServiceCIDR: cfg.Network.ServiceIPv4CIDR,
+				IPv4CIDR:     cfg.Network.IPv4CIDR,
+				NodeIPv4CIDR: cfg.Network.NodeIPv4CIDR,
+				PodCIDR:      cfg.Network.PodIPv4CIDR,
+				ServiceCIDR:  cfg.Network.ServiceIPv4CIDR,
 			},
 			Firewall: k8znerv1alpha1.FirewallSpec{
 				Enabled: true,

--- a/internal/operator/provisioning/adapter.go
+++ b/internal/operator/provisioning/adapter.go
@@ -456,10 +456,14 @@ func SpecToConfig(k8sCluster *k8znerv1alpha1.K8znerCluster, creds *Credentials) 
 		Location:    spec.Region,
 
 		// Network configuration
+		// NodeIPv4CIDR is critical for CCM subnet configuration - it determines
+		// where load balancers are attached in the private network.
 		Network: config.NetworkConfig{
-			IPv4CIDR:        defaultString(spec.Network.IPv4CIDR, "10.0.0.0/16"),
-			PodIPv4CIDR:     defaultString(spec.Network.PodCIDR, "10.244.0.0/16"),
-			ServiceIPv4CIDR: defaultString(spec.Network.ServiceCIDR, "10.96.0.0/16"),
+			IPv4CIDR:           defaultString(spec.Network.IPv4CIDR, "10.0.0.0/16"),
+			NodeIPv4CIDR:       defaultString(spec.Network.NodeIPv4CIDR, "10.0.0.0/17"),
+			NodeIPv4SubnetMask: 25, // /25 subnets for each role (126 IPs per subnet)
+			PodIPv4CIDR:        defaultString(spec.Network.PodCIDR, "10.0.128.0/17"),
+			ServiceIPv4CIDR:    defaultString(spec.Network.ServiceCIDR, "10.96.0.0/12"),
 		},
 
 		// Talos configuration


### PR DESCRIPTION
## Summary

- Fixes CCM "subnet not found" errors caused by CIDR mismatch between CLI and operator
- Adds `NodeIPv4CIDR` field to `K8znerCluster` CRD `NetworkSpec`
- Updates CLI to populate `NodeIPv4CIDR` when creating the CRD
- Updates operator adapter to use `NodeIPv4CIDR` with correct defaults matching v2 config

## Root Cause

The CCM was failing to discover load balancer subnets because:
- CLI v2 config uses `NodeCIDR = "10.0.0.0/17"` for subnet calculations
- Operator was recalculating subnets using a different default (`10.0.64.0/19`)
- This resulted in CCM being configured with `10.0.64.128/25` while the actual LB subnet was `10.0.0.128/25`

## Fix

Pass the `NodeIPv4CIDR` value through the CRD so the operator uses the same value the CLI used when creating the network.

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./internal/config/... ./internal/operator/... ./cmd/k8zner/...` passes
- [ ] E2E tests with DevCluster (will run after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)