### PR TITLE
fix: prevent duplicate workers and ensure cleanup of all cluster resources

### DIFF
--- a/internal/operator/provisioning/adapter.go
+++ b/internal/operator/provisioning/adapter.go
@@ -492,12 +492,15 @@ func SpecToConfig(k8sCluster *k8znerv1alpha1.K8znerCluster, creds *Credentials) 
 		},
 
 		// Worker configuration
+		// IMPORTANT: Workers are created by the reconciliation loop (scaleUpWorkers),
+		// NOT by the compute provisioner. Set Count=0 here to avoid duplicate workers.
+		// The reconciliation loop handles worker scaling based on CRD spec.Workers.Count.
 		Workers: []config.WorkerNodePool{
 			{
-				Name:       "worker",
+				Name:       "workers",
 				Location:   spec.Region,
 				ServerType: normalizeServerSize(spec.Workers.Size),
-				Count:      spec.Workers.Count,
+				Count:      0, // Workers created by reconcileWorkers, not compute provisioner
 			},
 		},
 

--- a/internal/provisioning/destroy/provisioner_test.go
+++ b/internal/provisioning/destroy/provisioner_test.go
@@ -130,8 +130,15 @@ func TestProvisionCallsCleanupWithCorrectLabels(t *testing.T) {
 	// Verify the captured labels
 	require.NotNil(t, capturedLabels)
 	assert.Equal(t, "production-cluster", capturedLabels["cluster"])
+	assert.Equal(t, "production-cluster", capturedLabels["k8zner.io/cluster"])
 
 	// Test ID should not be present
 	_, hasTestID := capturedLabels["test-id"]
 	assert.False(t, hasTestID, "test-id should not be present when not configured")
+
+	// IMPORTANT: managed-by should NOT be present in cleanup labels
+	// This ensures we clean up both CLI-created (managed-by: k8zner) and
+	// operator-created (managed-by: k8zner-operator) resources
+	_, hasManagedBy := capturedLabels["k8zner.io/managed-by"]
+	assert.False(t, hasManagedBy, "k8zner.io/managed-by should NOT be present - cleanup should match all cluster resources regardless of manager")
 }


### PR DESCRIPTION
## Summary

Two critical fixes for E2E test stability discovered during test debugging:

- **Fix duplicate worker creation**: Set `Workers.Count=0` in phase adapter so workers are created ONLY by `reconcileWorkers`, not by the compute provisioner
- **Fix cleanup to delete all resources**: Changed cleanup label selector to use only cluster labels, not `managed-by`, ensuring both CLI and operator-created resources are cleaned up

## Changes

### 1. Cleanup Label Selector (`internal/provisioning/destroy/provisioner.go`)

Previously, cleanup filtered by `k8zner.io/managed-by: k8zner`, which missed operator-created resources that have `managed-by: k8zner-operator`. Now cleanup uses only:
- `k8zner.io/cluster: {cluster-name}`
- `cluster: {cluster-name}` (legacy)

### 2. Worker Provisioning Architecture (`internal/operator/provisioning/adapter.go`)

Previously, the phase adapter set `Workers.Count=spec.Workers.Count`, causing the compute provisioner to create workers. This resulted in duplicate workers:
- `cluster-worker-1` (from compute provisioner)
- `cluster-w-xxxxx` (from reconcileWorkers)

Now `Workers.Count=0` in the adapter, so workers are created ONLY by `reconcileWorkers`.

Also unified pool name from "worker" to "workers" for label consistency.

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Destroy provisioner tests verify `managed-by` is NOT in cleanup labels
- [ ] E2E test validates no duplicate workers are created
- [ ] E2E test validates cleanup removes all resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)