### PR TITLE
fix: add missing TalosCCM version in operator adapter

### DIFF
--- a/internal/operator/provisioning/adapter.go
+++ b/internal/operator/provisioning/adapter.go
@@ -543,7 +543,8 @@ func SpecToConfig(k8sCluster *k8znerv1alpha1.K8znerCluster, creds *Credentials) 
 			},
 			// Core addons
 			TalosCCM: config.TalosCCMConfig{
-				Enabled: true, // Node lifecycle management
+				Enabled: true,      // Node lifecycle management
+				Version: "v1.11.0", // Pinned Talos CCM version
 			},
 			Cilium: config.CiliumConfig{
 				Enabled: true,


### PR DESCRIPTION
## Summary

- Fixed a critical bug where the operator's `adapter.go` `SpecToConfig` function was not setting the `TalosCCM.Version` field
- This resulted in a malformed URL with a double slash that caused a 404 error when trying to download the Talos CCM manifest
- The bug blocked addon installation and prevented worker provisioning from proceeding

## Root Cause

The error in operator logs was:
```
failed to install Talos CCM: failed to apply Talos CCM from https://raw.githubusercontent.com/siderolabs/talos-cloud-controller-manager//docs/deploy/cloud-controller-manager-daemonset.yml: HTTP 404
```

Note the double slash (`//docs`) - this was because `Version` was empty, and the URL template `%s/docs/deploy/...` produced `"/docs/..."`.

## Fix

Added the pinned version `v1.11.0` to the TalosCCM config in `adapter.go`, matching the version defined in `internal/config/v2/versions.go`.

## Test plan

- [ ] Unit tests pass
- [ ] E2E tests pass with workers being provisioned correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)