### PR TITLE
fix: add not-ready toleration to CSI and Hubble relay for bootstrap scheduling

### DIFF
--- a/internal/addons/cilium.go
+++ b/internal/addons/cilium.go
@@ -300,6 +300,11 @@ func buildCiliumHubbleConfig(cfg *config.Config) helm.Values {
 					"key":      "node.cloudprovider.kubernetes.io/uninitialized",
 					"operator": "Exists",
 				},
+				{
+					// Tolerate not-ready nodes to ensure Hubble relay can start during bootstrap
+					"key":      "node.kubernetes.io/not-ready",
+					"operator": "Exists",
+				},
 			},
 		}
 	}

--- a/internal/addons/csi_test.go
+++ b/internal/addons/csi_test.go
@@ -73,12 +73,14 @@ func TestBuildCSIValues(t *testing.T) {
 			require.True(t, ok)
 			assert.Contains(t, nodeSelector, "node-role.kubernetes.io/control-plane")
 
-			// Check tolerations (should have control-plane and CCM uninitialized)
+			// Check tolerations (control-plane, uninitialized, and not-ready)
+			// All three are required for CSI to schedule during bootstrap
 			tolerations, ok := controller["tolerations"].([]helm.Values)
 			require.True(t, ok)
-			assert.Len(t, tolerations, 2)
+			assert.Len(t, tolerations, 3)
 			assert.Equal(t, "node-role.kubernetes.io/control-plane", tolerations[0]["key"])
 			assert.Equal(t, "node.cloudprovider.kubernetes.io/uninitialized", tolerations[1]["key"])
+			assert.Equal(t, "node.kubernetes.io/not-ready", tolerations[2]["key"])
 
 			// Check storage classes - we now have two: encrypted (default) and non-encrypted
 			storageClasses, ok := values["storageClasses"].([]helm.Values)


### PR DESCRIPTION
## Summary
- Add `node.kubernetes.io/not-ready` toleration to CSI controller
- Add `node.kubernetes.io/not-ready` toleration to Hubble relay
- Update CSI tests to expect 3 tolerations

## Test plan
- [x] Unit tests pass (`go test ./internal/addons/...`)
- [x] Lint passes (`golangci-lint run`)
- [ ] E2E test validates CSI can schedule during bootstrap

## Context
The CSI driver controller was failing to schedule during cluster bootstrap due to missing `node.kubernetes.io/not-ready` toleration. This is the same chicken-egg problem that was previously fixed for CCM in commit dc51e63.

Without all three tolerations (control-plane, uninitialized, not-ready), pods can't schedule on control plane nodes during bootstrap, causing CrashLoopBackOff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)