### PR TITLE
fix: post-render patch CSI controller dnsPolicy for bootstrap DNS resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
 	sigs.k8s.io/controller-runtime v0.19.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -202,5 +203,4 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/addons/csi.go
+++ b/internal/addons/csi.go
@@ -40,6 +40,14 @@ func applyCSI(ctx context.Context, client k8sclient.Client, cfg *config.Config) 
 		return fmt.Errorf("failed to render CSI chart: %w", err)
 	}
 
+	// Post-render: inject dnsPolicy since the CSI chart doesn't support it natively.
+	// Using host DNS avoids the CoreDNS dependency during bootstrap — without this,
+	// the CSI controller can't resolve api.hetzner.cloud and enters CrashLoopBackOff.
+	manifestBytes, err = patchDeploymentDNSPolicy(manifestBytes, "hcloud-csi-controller", "Default")
+	if err != nil {
+		return fmt.Errorf("failed to patch CSI controller dnsPolicy: %w", err)
+	}
+
 	// Apply manifests to cluster
 	if err := applyManifests(ctx, client, "hcloud-csi", manifestBytes); err != nil {
 		return fmt.Errorf("failed to apply CSI manifests: %w", err)
@@ -107,7 +115,6 @@ func buildCSIValues(cfg *config.Config) helm.Values {
 					"matchLabelKeys": []string{"pod-template-hash"},
 				},
 			},
-			"dnsPolicy": "Default",
 			"nodeSelector": helm.Values{
 				"node-role.kubernetes.io/control-plane": "",
 			},

--- a/internal/addons/csi_test.go
+++ b/internal/addons/csi_test.go
@@ -68,8 +68,8 @@ func TestBuildCSIValues(t *testing.T) {
 			assert.Equal(t, "kubernetes.io/hostname", tsc[0]["topologyKey"])
 			assert.Equal(t, "DoNotSchedule", tsc[0]["whenUnsatisfiable"])
 
-			// Check dnsPolicy - must use host DNS to avoid CoreDNS dependency during bootstrap
-			assert.Equal(t, "Default", controller["dnsPolicy"])
+			// Note: dnsPolicy is injected via post-render patching (patchDeploymentDNSPolicy),
+			// not as a helm value, because the CSI chart doesn't support it natively.
 
 			// Check node selector
 			nodeSelector, ok := controller["nodeSelector"].(helm.Values)

--- a/internal/addons/manifest_patch.go
+++ b/internal/addons/manifest_patch.go
@@ -1,0 +1,69 @@
+package addons
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// patchDeploymentDNSPolicy modifies rendered Helm YAML to set dnsPolicy on
+// a specific Deployment. This is a post-render patch for charts that don't
+// expose dnsPolicy as a configurable value.
+//
+// It splits multi-doc YAML into individual documents, finds the Deployment
+// matching deploymentName, sets spec.template.spec.dnsPolicy, and
+// re-serializes all docs back to multi-doc YAML.
+func patchDeploymentDNSPolicy(manifests []byte, deploymentName, dnsPolicy string) ([]byte, error) {
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(manifests), 4096)
+
+	var docs [][]byte
+	patched := false
+
+	for {
+		var raw unstructured.Unstructured
+		if err := decoder.Decode(&raw); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to decode YAML document: %w", err)
+		}
+
+		// Skip empty documents
+		if len(raw.Object) == 0 {
+			continue
+		}
+
+		// Check if this is the target Deployment
+		if raw.GetKind() == "Deployment" && raw.GetName() == deploymentName {
+			if err := unstructured.SetNestedField(raw.Object, dnsPolicy, "spec", "template", "spec", "dnsPolicy"); err != nil {
+				return nil, fmt.Errorf("failed to set dnsPolicy on %s: %w", deploymentName, err)
+			}
+			patched = true
+		}
+
+		out, err := sigsyaml.Marshal(raw.Object)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal YAML document: %w", err)
+		}
+		docs = append(docs, out)
+	}
+
+	if !patched {
+		return nil, fmt.Errorf("deployment %q not found in manifests", deploymentName)
+	}
+
+	// Join documents with YAML document separator
+	var buf bytes.Buffer
+	for i, doc := range docs {
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		buf.Write(doc)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/addons/manifest_patch_test.go
+++ b/internal/addons/manifest_patch_test.go
@@ -1,0 +1,128 @@
+package addons
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testMultiDocYAML = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hcloud-csi-controller
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hcloud-csi-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: hcloud-csi-driver
+        image: hetznercloud/hcloud-csi-driver:v2.18.3
+      dnsPolicy: ClusterFirst
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hcloud-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: hcloud-csi-driver
+        image: hetznercloud/hcloud-csi-driver:v2.18.3
+`
+
+func TestPatchDeploymentDNSPolicy(t *testing.T) {
+	t.Run("patches target deployment", func(t *testing.T) {
+		result, err := patchDeploymentDNSPolicy([]byte(testMultiDocYAML), "hcloud-csi-controller", "Default")
+		require.NoError(t, err)
+
+		resultStr := string(result)
+
+		// The patched deployment should have dnsPolicy: Default
+		assert.Contains(t, resultStr, "dnsPolicy: Default")
+		// Original ClusterFirst should be replaced
+		assert.NotContains(t, resultStr, "ClusterFirst")
+
+		// Other documents should still be present
+		assert.Contains(t, resultStr, "kind: ServiceAccount")
+		assert.Contains(t, resultStr, "kind: DaemonSet")
+		assert.Contains(t, resultStr, "hcloud-csi-node")
+	})
+
+	t.Run("preserves all documents", func(t *testing.T) {
+		result, err := patchDeploymentDNSPolicy([]byte(testMultiDocYAML), "hcloud-csi-controller", "Default")
+		require.NoError(t, err)
+
+		// Count YAML document separators - should have 2 separators for 3 documents
+		separators := strings.Count(string(result), "---\n")
+		assert.Equal(t, 2, separators, "should have 2 document separators for 3 documents")
+	})
+
+	t.Run("errors on non-matching deployment name", func(t *testing.T) {
+		_, err := patchDeploymentDNSPolicy([]byte(testMultiDocYAML), "nonexistent-deployment", "Default")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("does not modify other deployments", func(t *testing.T) {
+		multiDeployYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: target-deploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+      dnsPolicy: ClusterFirst
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: other-deploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+      dnsPolicy: ClusterFirst
+`
+		result, err := patchDeploymentDNSPolicy([]byte(multiDeployYAML), "target-deploy", "Default")
+		require.NoError(t, err)
+
+		// Split result back into documents and verify
+		docs := strings.Split(string(result), "---\n")
+		require.Len(t, docs, 2)
+
+		// First doc (target) should have Default
+		assert.Contains(t, docs[0], "dnsPolicy: Default")
+		// Second doc (other) should still have ClusterFirst
+		assert.Contains(t, docs[1], "dnsPolicy: ClusterFirst")
+	})
+
+	t.Run("adds dnsPolicy when not present", func(t *testing.T) {
+		noPolicyYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+`
+		result, err := patchDeploymentDNSPolicy([]byte(noPolicyYAML), "my-deploy", "Default")
+		require.NoError(t, err)
+		assert.Contains(t, string(result), "dnsPolicy: Default")
+	})
+}

--- a/tests/e2e/phase_addons.go
+++ b/tests/e2e/phase_addons.go
@@ -359,7 +359,7 @@ func testCSIVolume(t *testing.T, state *E2EState) {
 	t.Log("  Testing CSI volume provisioning...")
 
 	// Wait for CSI controller to be ready before testing volume provisioning
-	waitForCSIReady(t, state.KubeconfigPath, 5*time.Minute)
+	waitForCSIReady(t, state.KubeconfigPath, 8*time.Minute)
 
 	pvcName := "e2e-csi-test-pvc"
 	podName := "e2e-csi-test-pod"


### PR DESCRIPTION
## Summary
- The hcloud-csi Helm chart v2.18.3 does **not** support `controller.dnsPolicy` as a configurable value — our previous helm value was silently ignored
- Added a post-render manifest patching utility (`patchDeploymentDNSPolicy`) that injects `dnsPolicy: Default` into the rendered CSI controller Deployment YAML
- This allows the CSI controller to use host DNS and resolve `api.hetzner.cloud` without depending on CoreDNS during bootstrap, preventing CrashLoopBackOff
- Increased E2E CSI readiness timeout from 5m to 8m for image pull margin

## Test plan
- [x] `go test ./internal/addons/ -run TestPatchDeployment` — new unit tests pass (5 cases)
- [x] `go test ./internal/addons/ -run TestBuildCSIValues` — existing test updated and passes
- [x] `go test ./tests/e2e/ -tags=e2e -c` — E2E code compiles
- [x] `golangci-lint run ./internal/addons/` — 0 issues
- [ ] E2E test — CSI controller should start without CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)