### PR TITLE
fix: update ArgoCD ingress values for Helm chart v9.x API

### DIFF
--- a/internal/addons/argocd.go
+++ b/internal/addons/argocd.go
@@ -292,13 +292,8 @@ func buildArgoCDIngress(cfg *config.Config, workerIPs []string) helm.Values {
 	argoCDCfg := cfg.Addons.ArgoCD
 
 	ingress := helm.Values{
-		"enabled": true,
-		"hosts": []string{
-			argoCDCfg.IngressHost,
-		},
-		// ArgoCD runs in insecure mode - Traefik handles TLS termination
-		// https: false means the ingress talks HTTP to the backend
-		"https": false,
+		"enabled":  true,
+		"hostname": argoCDCfg.IngressHost,
 	}
 
 	// Set ingress class if specified
@@ -307,15 +302,10 @@ func buildArgoCDIngress(cfg *config.Config, workerIPs []string) helm.Values {
 	}
 
 	// Configure TLS if enabled
+	// The v9.x chart uses tls: true (boolean) and derives the secret name
+	// from the hostname automatically (argocd-server-tls)
 	if argoCDCfg.IngressTLS {
-		ingress["tls"] = []helm.Values{
-			{
-				"hosts": []string{
-					argoCDCfg.IngressHost,
-				},
-				"secretName": "argocd-server-tls",
-			},
-		}
+		ingress["tls"] = true
 
 		// Build annotations for TLS and DNS
 		annotations := helm.Values{}

--- a/internal/addons/argocd_test.go
+++ b/internal/addons/argocd_test.go
@@ -317,22 +317,18 @@ func TestBuildArgoCDIngress(t *testing.T) {
 
 			assert.Equal(t, true, ingress["enabled"])
 
-			hosts, ok := ingress["hosts"].([]string)
+			hostname, ok := ingress["hostname"].(string)
 			require.True(t, ok)
-			require.Len(t, hosts, 1)
-			assert.Equal(t, tt.expectedHost, hosts[0])
+			assert.Equal(t, tt.expectedHost, hostname)
 
 			if tt.expectedClassName != "" {
 				assert.Equal(t, tt.expectedClassName, ingress["ingressClassName"])
 			}
 
 			if tt.expectTLS {
-				tls, ok := ingress["tls"].([]helm.Values)
+				tls, ok := ingress["tls"].(bool)
 				require.True(t, ok)
-				require.Len(t, tls, 1)
-				tlsHosts, ok := tls[0]["hosts"].([]string)
-				require.True(t, ok)
-				assert.Contains(t, tlsHosts, tt.expectedHost)
+				assert.True(t, tls)
 
 				// Check cluster issuer annotation
 				annotations, ok := ingress["annotations"].(helm.Values)


### PR DESCRIPTION
## Summary
- Update `buildArgoCDIngress()` to use v9.x chart API: `hostname` (string) instead of `hosts` (array), `tls: true` (boolean) instead of TLS array objects
- Remove obsolete `https: false` key that doesn't exist in v9.x
- The old v5.x format was silently ignored by the chart, producing no Ingress resource

## Test plan
- [x] `go test ./internal/addons/ -run TestBuildArgoCD` — all ArgoCD unit tests pass
- [x] `go test ./internal/addons/` — full addon test suite passes
- [x] `golangci-lint run ./internal/addons/` — no lint errors
- [ ] E2E test — ArgoCD ingress created, TLS working, dashboard accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)