### PR TITLE
fix: set machine config options in create/upgrade for CoreDNS

### DIFF
--- a/cmd/k8zner/handlers/create.go
+++ b/cmd/k8zner/handlers/create.go
@@ -20,6 +20,7 @@ import (
 	"github.com/imamik/k8zner/internal/config"
 	configv2 "github.com/imamik/k8zner/internal/config/v2"
 	hcloudInternal "github.com/imamik/k8zner/internal/platform/hcloud"
+	"github.com/imamik/k8zner/internal/platform/talos"
 	"github.com/imamik/k8zner/internal/provisioning"
 	"github.com/imamik/k8zner/internal/provisioning/cluster"
 	"github.com/imamik/k8zner/internal/provisioning/compute"
@@ -97,6 +98,9 @@ func Create(ctx context.Context, configPath string, wait bool) error {
 	if err != nil {
 		return err
 	}
+
+	// Set machine config options (CoreDNS, encryption, network settings, etc.)
+	talosGen.SetMachineConfigOptions(talos.NewMachineConfigOptions(cfg))
 
 	// Write Talos config and secrets early
 	if err := writeTalosFiles(talosGen); err != nil {

--- a/cmd/k8zner/handlers/upgrade.go
+++ b/cmd/k8zner/handlers/upgrade.go
@@ -79,6 +79,9 @@ func Upgrade(ctx context.Context, opts UpgradeOptions) error {
 		sb,
 	)
 
+	// Set machine config options (CoreDNS, encryption, network settings, etc.)
+	talosGen.SetMachineConfigOptions(talos.NewMachineConfigOptions(cfg))
+
 	// Create provisioning context
 	pCtx := newProvisioningContext(ctx, cfg, infraClient, talosGen)
 


### PR DESCRIPTION
## Summary

- The `Create` and `Upgrade` handlers bypassed the `Reconciler` and ran provisioning phases directly, but never called `SetMachineConfigOptions` on the Talos generator
- This left `MachineConfigOptions` zero-valued, causing `CoreDNSEnabled` (a `bool`, not `*bool`) to default to `false`
- The Talos patch generator then set `coreDNS.disabled=true`, leaving the cluster **without CoreDNS**
- ExternalDNS and other pods that need cluster DNS to resolve external APIs (e.g. `api.cloudflare.com`) crashed with `context deadline exceeded`

## Root Cause

The `Reconciler` (used by `apply`) correctly calls:
```go
machineOpts := talos.NewMachineConfigOptions(r.config)
r.talosGenerator.SetMachineConfigOptions(machineOpts)
```

But `Create` and `Upgrade` handlers skip the reconciler and run phases directly, never setting machine config options. The Talos `Generator` initializes with `&MachineConfigOptions{}` (all bools default to `false`), and the patch generator uses `!opts.CoreDNSEnabled` → `disabled: true`.

## Fix

Add `talosGen.SetMachineConfigOptions(talos.NewMachineConfigOptions(cfg))` to both `Create` and `Upgrade` handlers after initializing the Talos generator.

## Test plan

- [x] `go test ./cmd/k8zner/handlers/` passes
- [ ] E2E fullstack test — CoreDNS should be running, ExternalDNS creates DNS records

🤖 Generated with [Claude Code](https://claude.com/claude-code)