### PR TITLE
fix: operator hostNetwork API access for kube-proxy-free clusters

### DIFF
--- a/cmd/k8zner/handlers/create.go
+++ b/cmd/k8zner/handlers/create.go
@@ -265,12 +265,13 @@ func installOperatorOnly(ctx context.Context, cfg *config.Config, kubeconfig []b
 		cfg.Addons = savedAddons
 	}()
 
-	// Retry with backoff for transient errors (API server just started)
-	const maxRetries = 5
+	// Retry with backoff for transient errors (API server just started,
+	// LB health checks may take up to 5 minutes to mark backend healthy)
+	const maxRetries = 10
 	var lastErr error
 	for i := 0; i < maxRetries; i++ {
 		if i > 0 {
-			delay := time.Duration(i*10) * time.Second
+			delay := time.Duration(15) * time.Second
 			log.Printf("Retrying operator installation in %v (attempt %d/%d)...", delay, i+1, maxRetries)
 			select {
 			case <-ctx.Done():

--- a/internal/addons/operator-chart/templates/deployment.yaml
+++ b/internal/addons/operator-chart/templates/deployment.yaml
@@ -60,6 +60,12 @@ spec:
             - name: DEBUG
               value: "true"
             {{- end }}
+            {{- if .Values.hostNetwork }}
+            - name: KUBERNETES_SERVICE_HOST
+              value: "localhost"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
+            {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}


### PR DESCRIPTION
## Summary

- When kube-proxy is disabled (Cilium replaces it), the Kubernetes service IP (10.96.0.1) is not routable until Cilium is installed
- The operator runs **before** Cilium with `hostNetwork: true` on a control plane node
- controller-runtime connects to `KUBERNETES_SERVICE_HOST` (10.96.0.1 by default) which doesn't work without kube-proxy
- Set `KUBERNETES_SERVICE_HOST=localhost` and `KUBERNETES_SERVICE_PORT=6443` so the operator reaches kube-apiserver directly on the same node

## Root Cause

PR #131 fixed `SetMachineConfigOptions` in the create handler, which correctly enabled `KubeProxyReplacement: true`. This disabled kube-proxy (as intended — Cilium replaces it). However, the operator pod couldn't reach the API server through the service IP anymore, causing CrashLoopBackOff before Cilium was installed.

## Changes

1. **Operator chart**: When `hostNetwork` is enabled, inject `KUBERNETES_SERVICE_HOST=localhost` and `KUBERNETES_SERVICE_PORT=6443` env vars
2. **Create handler**: Increase operator install retries from 5→10 with fixed 15s intervals (handles LB health check propagation)

## Test plan

- [x] `go test ./cmd/k8zner/handlers/` passes
- [x] `go build ./...` succeeds
- [ ] E2E fullstack test — operator starts, Cilium installed, cluster reaches Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)