### PR TITLE
fix: CCM API access for kube-proxy-free clusters

### DIFF
--- a/internal/addons/ccm.go
+++ b/internal/addons/ccm.go
@@ -88,6 +88,13 @@ func buildCCMValues(cfg *config.Config, _ int64) helm.Values {
 	// Build environment variables for load balancer configuration
 	// See: terraform/hcloud.tf lines 39-54
 	env := buildCCMEnvVars(cfg, lb)
+
+	// CCM runs on control plane nodes with hostNetwork:true.
+	// When kube-proxy is disabled (Cilium replaces it), the Kubernetes service IP
+	// is not routable. Override to use localhost since kube-apiserver runs on the same node.
+	env["KUBERNETES_SERVICE_HOST"] = helm.Values{"value": "localhost"}
+	env["KUBERNETES_SERVICE_PORT"] = helm.Values{"value": "6443"}
+
 	if len(env) > 0 {
 		values["env"] = env
 	}

--- a/internal/addons/kubectl.go
+++ b/internal/addons/kubectl.go
@@ -22,30 +22,35 @@ func applyManifests(ctx context.Context, client k8sclient.Client, addonName stri
 // applyFromURL downloads a manifest from a URL and applies it using the k8sclient.
 // This is useful for applying CRDs or other manifests hosted remotely.
 func applyFromURL(ctx context.Context, client k8sclient.Client, addonName, manifestURL string) error {
-	// Create HTTP request with context
+	manifestBytes, err := fetchManifestURL(ctx, manifestURL)
+	if err != nil {
+		return err
+	}
+	return applyManifests(ctx, client, addonName, manifestBytes)
+}
+
+// fetchManifestURL downloads a manifest from a URL and returns the bytes.
+func fetchManifestURL(ctx context.Context, manifestURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create request for %s: %w", manifestURL, err)
+		return nil, fmt.Errorf("failed to create request for %s: %w", manifestURL, err)
 	}
 
-	// Download the manifest
 	httpClient := &http.Client{Timeout: 60 * time.Second}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to download manifest from %s: %w", manifestURL, err)
+		return nil, fmt.Errorf("failed to download manifest from %s: %w", manifestURL, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download manifest from %s: HTTP %d", manifestURL, resp.StatusCode)
+		return nil, fmt.Errorf("failed to download manifest from %s: HTTP %d", manifestURL, resp.StatusCode)
 	}
 
-	// Read the manifest content
 	manifestBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read manifest from %s: %w", manifestURL, err)
+		return nil, fmt.Errorf("failed to read manifest from %s: %w", manifestURL, err)
 	}
 
-	// Apply using the k8sclient
-	return applyManifests(ctx, client, addonName, manifestBytes)
+	return manifestBytes, nil
 }


### PR DESCRIPTION
## Summary

Companion to PR #132 — extends the hostNetwork API access fix to both CCMs.

- **Hetzner CCM**: Inject `KUBERNETES_SERVICE_HOST=localhost` via Helm env values
- **Talos CCM**: Post-render patch the upstream DaemonSet manifest to inject env vars
- Extract `fetchManifestURL` from `applyFromURL` for reuse with post-render patching
- Add reusable `patchHostNetworkAPIAccess` function for general hostNetwork API access

## Root Cause

Same as PR #132: with kube-proxy disabled, the Kubernetes service IP (10.96.0.1) is not routable until Cilium is installed. Both CCMs run on control plane nodes with `hostNetwork: true`, so they can reach kube-apiserver on `localhost:6443`.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/addons/` passes
- [x] `go test ./cmd/k8zner/handlers/` passes
- [ ] E2E fullstack test — CCM LB test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)