### PR TITLE
Persist ArgoCD and Grafana access data during cluster bootstrap

### DIFF
--- a/cmd/k8zner/handlers/access_data.go
+++ b/cmd/k8zner/handlers/access_data.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/imamik/k8zner/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+const accessDataPath = "access-data.yaml"
+
+type serviceAccessInfo struct {
+	Enabled  bool   `yaml:"enabled"`
+	URL      string `yaml:"url,omitempty"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+type clusterAccessData struct {
+	ClusterName string             `yaml:"cluster_name"`
+	SavedAt     string             `yaml:"saved_at"`
+	TalosConfig string             `yaml:"talos_config"`
+	Kubeconfig  string             `yaml:"kubeconfig"`
+	ArgoCD      *serviceAccessInfo `yaml:"argocd,omitempty"`
+	Grafana     *serviceAccessInfo `yaml:"grafana,omitempty"`
+}
+
+// persistAccessData writes cluster access details to disk and optionally enriches with addon credentials.
+func persistAccessData(ctx context.Context, cfg *config.Config, kubeconfig []byte, includeAddonCredentials bool) error {
+	data := buildAccessDataFromConfig(cfg)
+
+	if includeAddonCredentials {
+		if err := hydrateAddonCredentials(ctx, kubeconfig, data); err != nil {
+			log.Printf("Warning: failed to load addon credentials: %v", err)
+		}
+	}
+
+	content, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal access data: %w", err)
+	}
+
+	if err := writeFile(accessDataPath, content, 0600); err != nil {
+		return fmt.Errorf("failed to write access data: %w", err)
+	}
+
+	return nil
+}
+
+func buildAccessDataFromConfig(cfg *config.Config) *clusterAccessData {
+	data := &clusterAccessData{
+		ClusterName: cfg.ClusterName,
+		SavedAt:     time.Now().UTC().Format(time.RFC3339),
+		TalosConfig: talosConfigPath,
+		Kubeconfig:  kubeconfigPath,
+	}
+
+	if cfg.Addons.ArgoCD.Enabled {
+		data.ArgoCD = &serviceAccessInfo{
+			Enabled:  true,
+			URL:      buildServiceURL(cfg.Addons.ArgoCD.IngressHost),
+			Username: "admin",
+		}
+	}
+
+	if cfg.Addons.KubePrometheusStack.Enabled {
+		grafana := &serviceAccessInfo{
+			Enabled: true,
+			URL:     buildServiceURL(cfg.Addons.KubePrometheusStack.Grafana.IngressHost),
+		}
+		if cfg.Addons.KubePrometheusStack.Grafana.AdminPassword != "" {
+			grafana.Username = "admin"
+			grafana.Password = cfg.Addons.KubePrometheusStack.Grafana.AdminPassword
+		}
+		data.Grafana = grafana
+	}
+
+	return data
+}
+
+func buildServiceURL(host string) string {
+	if host == "" {
+		return ""
+	}
+	return "https://" + host
+}
+
+func hydrateAddonCredentials(ctx context.Context, kubeconfig []byte, data *clusterAccessData) error {
+	if len(kubeconfig) == 0 {
+		return nil
+	}
+
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	k8sClient, err := client.New(restCfg, client.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	if data.ArgoCD != nil {
+		secret := &corev1.Secret{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "argocd", Name: "argocd-initial-admin-secret"}, secret); err == nil {
+			if password, ok := secret.Data["password"]; ok {
+				data.ArgoCD.Password = string(password)
+			}
+		}
+	}
+
+	if data.Grafana != nil {
+		secret := &corev1.Secret{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "monitoring", Name: "kube-prometheus-stack-grafana"}, secret); err == nil {
+			if username, ok := secret.Data["admin-user"]; ok {
+				data.Grafana.Username = string(username)
+			}
+			if password, ok := secret.Data["admin-password"]; ok {
+				data.Grafana.Password = string(password)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/k8zner/handlers/access_data_test.go
+++ b/cmd/k8zner/handlers/access_data_test.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/imamik/k8zner/internal/config"
+)
+
+func TestBuildAccessDataFromConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ClusterName: "demo",
+		Addons: config.AddonsConfig{
+			ArgoCD: config.ArgoCDConfig{
+				Enabled:     true,
+				IngressHost: "argo.example.com",
+			},
+			KubePrometheusStack: config.KubePrometheusStackConfig{
+				Enabled: true,
+				Grafana: config.KubePrometheusGrafanaConfig{
+					IngressHost:   "grafana.example.com",
+					AdminPassword: "grafana-pass",
+				},
+			},
+		},
+	}
+
+	data := buildAccessDataFromConfig(cfg)
+	require.NotNil(t, data)
+	assert.Equal(t, "demo", data.ClusterName)
+	assert.Equal(t, talosConfigPath, data.TalosConfig)
+	assert.Equal(t, kubeconfigPath, data.Kubeconfig)
+	require.NotNil(t, data.ArgoCD)
+	assert.Equal(t, "https://argo.example.com", data.ArgoCD.URL)
+	assert.Equal(t, "admin", data.ArgoCD.Username)
+	require.NotNil(t, data.Grafana)
+	assert.Equal(t, "https://grafana.example.com", data.Grafana.URL)
+	assert.Equal(t, "admin", data.Grafana.Username)
+	assert.Equal(t, "grafana-pass", data.Grafana.Password)
+}
+
+func TestPersistAccessData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes file", func(t *testing.T) {
+		t.Parallel()
+		origWrite := writeFile
+		defer func() { writeFile = origWrite }()
+
+		var (
+			path string
+			perm os.FileMode
+		)
+		writeFile = func(p string, b []byte, m os.FileMode) error {
+			path = p
+			perm = m
+			assert.Contains(t, string(b), "cluster_name: demo")
+			assert.Contains(t, string(b), "argocd:")
+			assert.Contains(t, string(b), "grafana:")
+			return nil
+		}
+
+		cfg := &config.Config{
+			ClusterName: "demo",
+			Addons: config.AddonsConfig{
+				ArgoCD:              config.ArgoCDConfig{Enabled: true},
+				KubePrometheusStack: config.KubePrometheusStackConfig{Enabled: true},
+			},
+		}
+
+		err := persistAccessData(context.Background(), cfg, nil, false)
+		require.NoError(t, err)
+		assert.Equal(t, accessDataPath, path)
+		assert.Equal(t, os.FileMode(0600), perm)
+	})
+
+	t.Run("write error", func(t *testing.T) {
+		t.Parallel()
+		origWrite := writeFile
+		defer func() { writeFile = origWrite }()
+		writeFile = func(_ string, _ []byte, _ os.FileMode) error { return errors.New("disk full") }
+
+		cfg := &config.Config{ClusterName: "demo"}
+		err := persistAccessData(context.Background(), cfg, nil, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to write access data")
+	})
+}
+
+func TestBuildServiceURL(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", buildServiceURL(""))
+	assert.Equal(t, "https://argo.example.com", buildServiceURL("argo.example.com"))
+}

--- a/cmd/k8zner/handlers/apply.go
+++ b/cmd/k8zner/handlers/apply.go
@@ -235,6 +235,10 @@ func bootstrapNewCluster(ctx context.Context, cfg *config.Config, wait bool) err
 		return applyErr
 	}
 
+	if applyErr = persistAccessData(ctx, cfg, kubeconfig, wait); applyErr != nil {
+		return applyErr
+	}
+
 	// Gather infrastructure info for CRD
 	infraInfo := buildInfraInfo(ctx, pCtx, infraClient, cfg)
 
@@ -330,6 +334,10 @@ func bootstrapNewClusterTUI(ctx context.Context, cfg *config.Config, wait bool) 
 			return applyErr
 		}
 		ch <- tui.BootstrapPhaseMsg{Phase: "operator", Done: true}
+
+		if applyErr = persistAccessData(ctx, cfg, kubeconfig, wait); applyErr != nil {
+			return applyErr
+		}
 
 		// Phase 6: CRD
 		ch <- tui.BootstrapPhaseMsg{Phase: "crd"}

--- a/cmd/k8zner/handlers/bootstrap.go
+++ b/cmd/k8zner/handlers/bootstrap.go
@@ -207,6 +207,7 @@ func printApplySuccess(cfg *config.Config, wait bool) {
 	fmt.Printf("Secrets saved to: %s\n", secretsFile)
 	fmt.Printf("Talos config saved to: %s\n", talosConfigPath)
 	fmt.Printf("Kubeconfig saved to: %s\n", kubeconfigPath)
+	fmt.Printf("Access data saved to: %s\n", accessDataPath)
 
 	if !wait {
 		fmt.Printf("\nThe operator is now provisioning:\n")

--- a/cmd/k8zner/handlers/bootstrap_test.go
+++ b/cmd/k8zner/handlers/bootstrap_test.go
@@ -181,6 +181,7 @@ func TestPrintApplySuccess(t *testing.T) {
 		assert.Contains(t, output, "Secrets saved to")
 		assert.Contains(t, output, "Talos config saved to")
 		assert.Contains(t, output, "Kubeconfig saved to")
+		assert.Contains(t, output, "Access data saved to")
 		assert.Contains(t, output, "operator is now provisioning")
 		assert.Contains(t, output, "k8zner doctor --watch")
 		assert.Contains(t, output, "kubectl get nodes")


### PR DESCRIPTION
### Motivation
- When a cluster is created we already persist Talos secrets and the kubeconfig, but ArgoCD and Grafana access information (URLs and initial credentials) were not saved for users to consume after bootstrap.
- Persisting this data (and attempting to hydrate addon credentials when possible) makes post-bootstrap access and automation easier and reduces manual steps.

### Description
- Add a new persistence helper `persistAccessData` and supporting types in `cmd/k8zner/handlers/access_data.go` that build an `access-data.yaml` file containing Talos/kube paths plus ArgoCD and Grafana access fields.
- Wire `persistAccessData` into both non-TUI and TUI bootstrap flows immediately after operator installation so access information is saved as part of cluster creation.
- Implement best-effort addon credential hydration that, when a kubeconfig is available and `--wait` is used, reads `argocd/argocd-initial-admin-secret` and `monitoring/kube-prometheus-stack-grafana` to populate passwords/usernames without failing the bootstrap on error.
- Update bootstrap success output to print the `access-data.yaml` path and add `cmd/k8zner/handlers/access_data_test.go` plus small test updates to `bootstrap_test.go` to cover the new behavior.

### Testing
- Ran code formatting with `gofmt -w` on the changed handler files (success).
- Added unit tests for `buildAccessDataFromConfig`, `persistAccessData`, and `buildServiceURL` in `cmd/k8zner/handlers/access_data_test.go` and updated `bootstrap_test.go` to assert the new success message (tests included in the change).
- Attempted to run a focused test run with `go test ./cmd/k8zner/handlers -run TestBuildServiceURL -count=1`, but the test invocation timed out in this environment (`EXIT:124`); broader test runs were attempted but were not completed here due to environment timeouts or cancellations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e555653448329b65fedce4167dd40)