### PR TITLE
Wire metrics-server into monitoring health checks and Prometheus scraping

### DIFF
--- a/internal/addons/metrics_server.go
+++ b/internal/addons/metrics_server.go
@@ -55,6 +55,13 @@ func buildMetricsServerValues(cfg *config.Config) helm.Values {
 		},
 	}
 
+	// Wire metrics-server into Prometheus when monitoring stack is enabled.
+	if cfg.Addons.KubePrometheusStack.Enabled {
+		values["serviceMonitor"] = helm.Values{
+			"enabled": true,
+		}
+	}
+
 	if scheduleOnControlPlane {
 		values["nodeSelector"] = helm.ControlPlaneNodeSelector()
 		values["tolerations"] = []helm.Values{

--- a/internal/addons/metrics_server_test.go
+++ b/internal/addons/metrics_server_test.go
@@ -9,6 +9,35 @@ import (
 	"github.com/imamik/k8zner/internal/config"
 )
 
+func TestBuildMetricsServerValues_ServiceMonitorWhenMonitoringEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ControlPlane: config.ControlPlaneConfig{NodePools: []config.ControlPlaneNodePool{{Count: 1}}},
+		Workers:      []config.WorkerNodePool{{Count: 1}},
+		Addons: config.AddonsConfig{
+			KubePrometheusStack: config.KubePrometheusStackConfig{Enabled: true},
+		},
+	}
+
+	values := buildMetricsServerValues(cfg)
+	svcMon, ok := values["serviceMonitor"].(helm.Values)
+	assert.True(t, ok)
+	assert.Equal(t, true, svcMon["enabled"])
+}
+
+func TestBuildMetricsServerValues_NoServiceMonitorWhenMonitoringDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		ControlPlane: config.ControlPlaneConfig{NodePools: []config.ControlPlaneNodePool{{Count: 1}}},
+		Workers:      []config.WorkerNodePool{{Count: 1}},
+	}
+
+	values := buildMetricsServerValues(cfg)
+	assert.Nil(t, values["serviceMonitor"])
+}
+
 func TestBuildMetricsServerValues_Tolerations(t *testing.T) {
 	t.Parallel()
 	// When scheduling on control plane, should have 2 tolerations

--- a/internal/operator/controller/reconcile_addon_health.go
+++ b/internal/operator/controller/reconcile_addon_health.go
@@ -152,8 +152,11 @@ func checkMonitoring(ctx context.Context, r *ClusterReconciler) (bool, string) {
 		}
 	}
 
-	if promReady && grafanaReady {
-		return true, "prometheus and grafana ready"
+	// Check Metrics APIService (served by metrics-server) to verify full metrics pipeline.
+	metricsAPIReady := r.checkMetricsAPI(ctx)
+
+	if promReady && grafanaReady && metricsAPIReady {
+		return true, "metrics-server, prometheus, and grafana ready"
 	}
-	return false, fmt.Sprintf("prometheus=%v, grafana=%v", promReady, grafanaReady)
+	return false, fmt.Sprintf("metricsAPI=%v, prometheus=%v, grafana=%v", metricsAPIReady, promReady, grafanaReady)
 }


### PR DESCRIPTION
### Motivation

- Ensure the monitoring pipeline (metrics-server → Prometheus → Grafana) is correctly wired so Prometheus can scrape `metrics-server` and the operator can rely on the metrics API when deciding health/replacement actions.
- Make monitoring addon health reflect the full metrics pipeline rather than only Prometheus/Grafana readiness to avoid false-positive healthy states.

### Description

- Enable the `metrics-server` chart `serviceMonitor` automatically when `kube-prometheus-stack` is enabled so Prometheus will scrape metrics-server (`internal/addons/metrics_server.go`).
- Tighten the monitoring health check to require the metrics API (`v1beta1.metrics.k8s.io`) in addition to Prometheus and Grafana readiness, and update the health message to include the metrics API status (`internal/operator/controller/reconcile_addon_health.go`).
- Add unit tests covering the new ServiceMonitor wiring behavior (`internal/addons/metrics_server_test.go`) and monitoring addon health passing/failing depending on metrics API availability (`internal/operator/controller/reconcile_addon_health_test.go`).
- Modified files: `internal/addons/metrics_server.go`, `internal/addons/metrics_server_test.go`, `internal/operator/controller/reconcile_addon_health.go`, `internal/operator/controller/reconcile_addon_health_test.go`.

### Testing

- Ran unit tests for the addons package for the new metrics-server behavior with `go test ./internal/addons -run 'TestBuildMetricsServerValues_(ServiceMonitorWhenMonitoringEnabled|NoServiceMonitorWhenMonitoringDisabled)' -count=1`, which passed.
- Ran the controller addon health tests with `go test ./internal/operator/controller -run TestReconcileAddonHealth -count=1 -timeout 90s`, which passed.
- All added/updated tests succeeded locally (`ok` for both targeted packages).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e5564c31c8329b1e28979a3337086)