### PR TITLE
harden operator and platform clients for production use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,9 +43,9 @@ jobs:
           version: v2.11.4
           args: --timeout=5m
 
-      - name: Check CRD and operator chart copies are in sync
+      - name: Check generated manifests and chart copies are in sync
         run: |
-          make check-crds
+          make check-manifests
           make check-operator-chart
 
   # ==========================================================================

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,11 @@ jobs:
           version: v2.11.4
           args: --timeout=5m
 
+      - name: Check CRD and operator chart copies are in sync
+        run: |
+          make check-crds
+          make check-operator-chart
+
   # ==========================================================================
   # Security scanning
   # ==========================================================================
@@ -67,7 +72,7 @@ jobs:
           govulncheck ./...
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -63,15 +63,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Update Helm chart version
-        run: |
-          VERSION=${{ steps.version.outputs.version_short }}
-          sed -i "s/^version:.*/version: ${VERSION}/" deploy/helm/k8zner-operator/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" deploy/helm/k8zner-operator/Chart.yaml
-
       - name: Package Helm chart
         run: |
-          helm package deploy/helm/k8zner-operator -d .helm-packages
+          VERSION=${{ steps.version.outputs.version_short }}
+          helm package deploy/helm/k8zner-operator -d .helm-packages \
+            --version "${VERSION}" --app-version "${VERSION}"
+
+      - name: Push Helm chart to GHCR
+        run: |
+          VERSION=${{ steps.version.outputs.version_short }}
+          helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin <<< "${{ secrets.GITHUB_TOKEN }}"
+          helm push ".helm-packages/k8zner-operator-${VERSION}.tgz" "oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -87,7 +89,8 @@ jobs:
             kubectl apply -f https://github.com/${{ github.repository }}/releases/download/operator-${{ steps.version.outputs.version }}/k8zner.io_k8znerclusters.yaml
 
             # Install operator via Helm
-            helm install k8zner-operator oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-chart:${{ steps.version.outputs.version_short }} \
+            helm install k8zner-operator oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/k8zner-operator \
+              --version ${{ steps.version.outputs.version_short }} \
               --namespace k8zner-system \
               --create-namespace \
               --set credentials.hcloudToken=$HCLOUD_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ tests/e2e/access-data.yaml
 # Downloaded tools (at root only)
 /hcloud
 /hcloud-*.tar.gz
-*.tar.gz.*
+*.tar.gz.*/operator

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,5 +1,6 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+# Keep in sync with the go directive in go.mod
+FROM golang:1.26.3-alpine AS builder
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: fmt lint test test-coverage test-unit test-integration test-kind build install check e2e e2e-fast e2e-snapshot-only clean help \
-       setup-hooks scan-secrets setup-envtest setup-kind sync-crds check-crds sync-operator-chart check-operator-chart
+       setup-hooks scan-secrets setup-envtest setup-kind sync-crds check-crds sync-operator-chart check-operator-chart \
+       generate manifests check-manifests
 
 # Default target
 .DEFAULT_GOAL := help
@@ -8,6 +9,10 @@
 ENVTEST_K8S_VERSION ?= 1.35.0
 ENVTEST_ASSETS_DIR ?= $(shell pwd)/bin/envtest
 ENVTEST := $(shell pwd)/bin/setup-envtest
+
+# Code generation
+CONTROLLER_GEN_VERSION ?= v0.20.0
+CONTROLLER_GEN := $(shell pwd)/bin/controller-gen
 
 fmt:
 	go fmt ./...
@@ -96,6 +101,25 @@ e2e-fast:
 # Useful for verifying image builder changes
 e2e-snapshot-only:
 	go test -v -timeout=30m -tags=e2e -run TestSnapshotCreation ./tests/e2e/...
+
+# Regenerate deepcopy functions from api/ types
+generate: $(CONTROLLER_GEN)
+	$(CONTROLLER_GEN) object paths=./api/...
+
+# Regenerate CRD manifests from api/ types and propagate to all copies
+manifests: $(CONTROLLER_GEN) generate
+	$(CONTROLLER_GEN) crd paths=./api/... output:crd:artifacts:config=config/crd/bases
+	$(MAKE) sync-crds
+
+# Check that generated manifests and deepcopy code are up to date (for CI)
+check-manifests: manifests
+	@git diff --exit-code config/crd deploy/crds internal/addons/operator-chart/crds api/v1alpha1/zz_generated.deepcopy.go || \
+		(echo "ERROR: generated manifests out of date. Run 'make manifests' and commit the result." && exit 1)
+	@echo "Generated manifests up to date."
+
+$(CONTROLLER_GEN):
+	@mkdir -p $(shell pwd)/bin
+	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
 # Sync CRD from canonical source to deploy/ and operator-chart/
 sync-crds:

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ manifests: $(CONTROLLER_GEN) generate
 
 # Check that generated manifests and deepcopy code are up to date (for CI)
 check-manifests: manifests
-	@git diff --exit-code config/crd deploy/crds internal/addons/operator-chart/crds api/v1alpha1/zz_generated.deepcopy.go || \
+	@git diff --exit-code config/crd deploy/crds internal/addons/operator-chart/crds internal/operator/crds/manifests api/v1alpha1/zz_generated.deepcopy.go || \
 		(echo "ERROR: generated manifests out of date. Run 'make manifests' and commit the result." && exit 1)
 	@echo "Generated manifests up to date."
 
@@ -121,11 +121,13 @@ $(CONTROLLER_GEN):
 	@mkdir -p $(shell pwd)/bin
 	GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
-# Sync CRD from canonical source to deploy/ and operator-chart/
+# Sync CRD from canonical source to deploy/, operator-chart/, and the
+# operator's embedded copy (self-applied at startup).
 sync-crds:
 	@echo "Syncing CRDs from config/crd/bases/ ..."
 	cp config/crd/bases/k8zner.io_k8znerclusters.yaml deploy/crds/k8zner.io_k8znerclusters.yaml
 	cp config/crd/bases/k8zner.io_k8znerclusters.yaml internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml
+	cp config/crd/bases/k8zner.io_k8znerclusters.yaml internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml
 	@echo "CRDs synced."
 
 # Check that CRD copies are in sync (for CI)
@@ -134,6 +136,8 @@ check-crds:
 		(echo "ERROR: deploy/crds/ CRD out of sync. Run 'make sync-crds'" && exit 1)
 	@diff -q config/crd/bases/k8zner.io_k8znerclusters.yaml internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml || \
 		(echo "ERROR: operator-chart/crds/ CRD out of sync. Run 'make sync-crds'" && exit 1)
+	@diff -q config/crd/bases/k8zner.io_k8znerclusters.yaml internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml || \
+		(echo "ERROR: internal/operator/crds/manifests/ CRD out of sync. Run 'make sync-crds'" && exit 1)
 	@echo "CRDs in sync."
 
 # Sync operator chart from deploy/helm/ (source of truth) to internal/addons/operator-chart/

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -272,6 +272,12 @@ type AddonSpec struct {
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`
 	GrafanaSubdomain string `json:"grafanaSubdomain,omitempty"`
+
+	// WildcardCertificate additionally issues a "*.{domain}" certificate via
+	// DNS01 and sets it as Traefik's default certificate, so ingresses
+	// without an explicit TLS secret are covered. Requires domain.
+	// +optional
+	WildcardCertificate bool `json:"wildcardCertificate,omitempty"`
 }
 
 // K8znerClusterStatus defines the observed state of K8znerCluster.

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -716,6 +716,10 @@ const (
 	ConditionImageReady = "ImageReady"
 	// ConditionBootstrapped indicates the cluster has been bootstrapped
 	ConditionBootstrapped = "Bootstrapped"
+	// ConditionUpToDate indicates node versions match the spec
+	// (False means an upgrade is pending; the operator does not perform
+	// node upgrades itself — run `k8zner apply` to roll them out)
+	ConditionUpToDate = "UpToDate"
 )
 
 // Credentials Secret keys

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -12,6 +12,7 @@ import (
 type K8znerClusterSpec struct {
 	// Region is the Hetzner Cloud region (e.g., fsn1, nbg1, hel1)
 	// +kubebuilder:validation:Enum=fsn1;nbg1;hel1
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="region is immutable"
 	Region string `json:"region"`
 
 	// ControlPlanes defines the control plane configuration
@@ -57,9 +58,14 @@ type K8znerClusterSpec struct {
 	// Domain is the base domain for ingress resources (e.g., "example.com").
 	// When set, addons like ArgoCD and Grafana will have ingress automatically configured.
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$`
 	Domain string `json:"domain,omitempty"`
 
-	// CredentialsRef references the Secret containing HCloud token and Talos secrets
+	// CredentialsRef references the Secret containing HCloud token and Talos secrets.
+	// Once set, it cannot be changed or removed: swapping credentials mid-lifecycle
+	// would silently re-point provisioning at a different Hetzner project.
+	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.name) || oldSelf.name == \"\" || (has(self.name) && self.name == oldSelf.name)",message="credentialsRef is immutable once set"
 	CredentialsRef corev1.LocalObjectReference `json:"credentialsRef"`
 
 	// Bootstrap contains the state from CLI bootstrap (if applicable)
@@ -256,11 +262,15 @@ type AddonSpec struct {
 	// ArgoSubdomain overrides the default "argo" subdomain for ArgoCD ingress.
 	// The full host will be "{argoSubdomain}.{domain}".
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`
 	ArgoSubdomain string `json:"argoSubdomain,omitempty"`
 
 	// GrafanaSubdomain overrides the default "grafana" subdomain for Grafana ingress.
 	// The full host will be "{grafanaSubdomain}.{domain}".
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`
 	GrafanaSubdomain string `json:"grafanaSubdomain,omitempty"`
 }
 

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -259,6 +259,10 @@ type AddonSpec struct {
 	// +optional
 	Monitoring bool `json:"monitoring,omitempty"`
 
+	// Logging enables the Loki + Alloy log aggregation stack
+	// +optional
+	Logging bool `json:"logging,omitempty"`
+
 	// ArgoSubdomain overrides the default "argo" subdomain for ArgoCD ingress.
 	// The full host will be "{argoSubdomain}.{domain}".
 	// +optional

--- a/cmd/k8zner/commands/kubeconfig.go
+++ b/cmd/k8zner/commands/kubeconfig.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/milankappen/k8zner/cmd/k8zner/handlers"
+)
+
+// Kubeconfig returns the command for generating scoped kubeconfigs.
+//
+// Required flags:
+//
+//	--read-only: generate a read-only kubeconfig (the only supported scope)
+//
+// Optional flags:
+//
+//	--kubeconfig: path to the admin kubeconfig (default: kubeconfig)
+//	--output, -o: where to write the generated kubeconfig (default: kubeconfig-readonly)
+//	--duration: token lifetime, e.g. 720h (default: 8760h = 1 year)
+func Kubeconfig() *cobra.Command {
+	var (
+		readOnly      bool
+		adminPath     string
+		outputPath    string
+		tokenDuration time.Duration
+	)
+
+	cmd := &cobra.Command{
+		Use:   "kubeconfig",
+		Short: "Generate a scoped kubeconfig for the cluster",
+		Long: `Generate a scoped kubeconfig for sharing cluster access.
+
+Currently supports read-only access: a ServiceAccount token bound to the
+built-in "view" ClusterRole. The "view" role grants no access to Secrets,
+so the generated kubeconfig is safe to hand to teammates who need to
+inspect workloads but must not read credentials.
+
+Examples:
+  # Generate a read-only kubeconfig valid for one year
+  k8zner kubeconfig --read-only
+
+  # Shorter-lived token, custom output path
+  k8zner kubeconfig --read-only --duration 720h -o ./readonly.yaml`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return handlers.Kubeconfig(cmd.Context(), adminPath, outputPath, readOnly, tokenDuration)
+		},
+	}
+
+	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Generate a read-only kubeconfig (required)")
+	cmd.Flags().StringVar(&adminPath, "kubeconfig", "kubeconfig", "Path to the admin kubeconfig")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "kubeconfig-readonly", "Output path for the generated kubeconfig")
+	cmd.Flags().DurationVar(&tokenDuration, "duration", 8760*time.Hour, "Token lifetime (e.g. 720h)")
+
+	return cmd
+}

--- a/cmd/k8zner/commands/root.go
+++ b/cmd/k8zner/commands/root.go
@@ -24,6 +24,7 @@ func Root() *cobra.Command {
 	cmd.AddCommand(Doctor())
 	cmd.AddCommand(Cost())
 	cmd.AddCommand(Secrets())
+	cmd.AddCommand(Kubeconfig())
 
 	// Utility commands
 	cmd.AddCommand(Version())

--- a/cmd/k8zner/commands/root_test.go
+++ b/cmd/k8zner/commands/root_test.go
@@ -25,6 +25,7 @@ func TestRoot_HasSubcommands(t *testing.T) {
 		"doctor",
 		"cost",
 		"secrets",
+		"kubeconfig",
 		"version",
 		"completion",
 	}
@@ -41,5 +42,5 @@ func TestRoot_HasSubcommands(t *testing.T) {
 
 func TestRoot_SubcommandCount(t *testing.T) {
 	cmd := Root()
-	assert.Len(t, cmd.Commands(), 8, "Expected 8 subcommands")
+	assert.Len(t, cmd.Commands(), 9, "Expected 9 subcommands")
 }

--- a/cmd/k8zner/handlers/apply.go
+++ b/cmd/k8zner/handlers/apply.go
@@ -33,8 +33,9 @@ const (
 	talosConfigPath = "talosconfig"
 	kubeconfigPath  = "kubeconfig"
 
-	// k8znerNamespace is the Kubernetes namespace for k8zner resources.
-	k8znerNamespace = "k8zner-system"
+	// k8znerNamespace is the Kubernetes namespace for k8zner resources,
+	// shared with the TUI layer so both look in the same place.
+	k8znerNamespace = tui.Namespace
 
 	// credentialsSecretName is the name of the secret containing Hetzner and Talos credentials.
 	credentialsSecretName = "k8zner-credentials" //nolint:gosec // This is a secret name, not a credential value

--- a/cmd/k8zner/handlers/apply.go
+++ b/cmd/k8zner/handlers/apply.go
@@ -378,6 +378,8 @@ func updateClusterSpecFromConfig(k8zCluster *k8znerv1alpha1.K8znerCluster, cfg *
 	k8zCluster.Spec.Addons.Traefik = cfg.Addons.Traefik.Enabled
 	k8zCluster.Spec.Addons.ArgoCD = cfg.Addons.ArgoCD.Enabled
 	k8zCluster.Spec.Addons.Monitoring = cfg.Addons.KubePrometheusStack.Enabled
+	k8zCluster.Spec.Addons.Logging = cfg.Addons.Logging.Enabled
+	k8zCluster.Spec.Addons.WildcardCertificate = cfg.Addons.CertManager.Cloudflare.WildcardCertificate
 
 	if cfg.Addons.TalosBackup.Enabled && cfg.Addons.TalosBackup.S3AccessKey != "" {
 		if k8zCluster.Spec.Backup == nil {

--- a/cmd/k8zner/handlers/cluster_crd.go
+++ b/cmd/k8zner/handlers/cluster_crd.go
@@ -224,12 +224,14 @@ func buildClusterStatus(cfg *config.Config, infraInfo *InfrastructureInfo, boots
 // buildAddonSpec creates the addon spec from config.
 func buildAddonSpec(cfg *config.Config) *k8znerv1alpha1.AddonSpec {
 	spec := &k8znerv1alpha1.AddonSpec{
-		Traefik:       cfg.Addons.Traefik.Enabled,
-		CertManager:   cfg.Addons.CertManager.Enabled,
-		ExternalDNS:   cfg.Addons.ExternalDNS.Enabled,
-		ArgoCD:        cfg.Addons.ArgoCD.Enabled,
-		MetricsServer: cfg.Addons.MetricsServer.Enabled,
-		Monitoring:    cfg.Addons.KubePrometheusStack.Enabled,
+		Traefik:             cfg.Addons.Traefik.Enabled,
+		CertManager:         cfg.Addons.CertManager.Enabled,
+		ExternalDNS:         cfg.Addons.ExternalDNS.Enabled,
+		ArgoCD:              cfg.Addons.ArgoCD.Enabled,
+		MetricsServer:       cfg.Addons.MetricsServer.Enabled,
+		Monitoring:          cfg.Addons.KubePrometheusStack.Enabled,
+		Logging:             cfg.Addons.Logging.Enabled,
+		WildcardCertificate: cfg.Addons.CertManager.Cloudflare.WildcardCertificate,
 	}
 
 	domain := cfg.Addons.Cloudflare.Domain

--- a/cmd/k8zner/handlers/cluster_crd_test.go
+++ b/cmd/k8zner/handlers/cluster_crd_test.go
@@ -143,8 +143,10 @@ func TestBuildAddonSpec(t *testing.T) {
 				ArgoCD:              config.ArgoCDConfig{Enabled: true},
 				MetricsServer:       config.MetricsServerConfig{Enabled: true},
 				KubePrometheusStack: config.KubePrometheusStackConfig{Enabled: true},
+				Logging:             config.LoggingConfig{Enabled: true},
 			},
 		}
+		cfg.Addons.CertManager.Cloudflare.WildcardCertificate = true
 
 		spec := buildAddonSpec(cfg)
 		assert.True(t, spec.Traefik)
@@ -153,6 +155,8 @@ func TestBuildAddonSpec(t *testing.T) {
 		assert.True(t, spec.ArgoCD)
 		assert.True(t, spec.MetricsServer)
 		assert.True(t, spec.Monitoring)
+		assert.True(t, spec.Logging)
+		assert.True(t, spec.WildcardCertificate)
 	})
 
 	t.Run("all disabled by default", func(t *testing.T) {
@@ -166,6 +170,8 @@ func TestBuildAddonSpec(t *testing.T) {
 		assert.False(t, spec.ArgoCD)
 		assert.False(t, spec.MetricsServer)
 		assert.False(t, spec.Monitoring)
+		assert.False(t, spec.Logging)
+		assert.False(t, spec.WildcardCertificate)
 	})
 
 	t.Run("extracts custom argo subdomain", func(t *testing.T) {

--- a/cmd/k8zner/handlers/destroy.go
+++ b/cmd/k8zner/handlers/destroy.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/milankappen/k8zner/internal/config"
 	"github.com/milankappen/k8zner/internal/platform/cloudflare"
+	"github.com/milankappen/k8zner/internal/platform/dns"
 	"github.com/milankappen/k8zner/internal/provisioning/destroy"
 )
 
@@ -217,15 +218,21 @@ func deleteS3Bucket(ctx context.Context, client *s3.Client, bucketName string) e
 	return nil
 }
 
+// newDNSProvider creates the DNS backend used for record cleanup.
+// Package-level for test injection, like the other handler factories.
+var newDNSProvider = func(apiToken string) dns.Provider {
+	return cloudflare.NewClient(apiToken)
+}
+
 // cleanupCloudflareDNS removes DNS records owned by this cluster from Cloudflare.
 // Records are identified via TXT ownership records created by external-dns.
 func cleanupCloudflareDNS(ctx context.Context, cfg *config.Config) error {
-	cfClient := cloudflare.NewClient(cfg.Addons.Cloudflare.APIToken)
+	provider := newDNSProvider(cfg.Addons.Cloudflare.APIToken)
 
 	zoneID := cfg.Addons.Cloudflare.ZoneID
 	if zoneID == "" {
 		var err error
-		zoneID, err = cfClient.GetZoneID(ctx, cfg.Addons.Cloudflare.Domain)
+		zoneID, err = provider.GetZoneID(ctx, cfg.Addons.Cloudflare.Domain)
 		if err != nil {
 			return fmt.Errorf("failed to get zone ID for %s: %w", cfg.Addons.Cloudflare.Domain, err)
 		}
@@ -237,7 +244,7 @@ func cleanupCloudflareDNS(ctx context.Context, cfg *config.Config) error {
 		ownerID = cfg.ClusterName
 	}
 
-	count, err := cfClient.CleanupClusterRecords(ctx, zoneID, ownerID)
+	count, err := provider.CleanupClusterRecords(ctx, zoneID, ownerID)
 	if err != nil {
 		return fmt.Errorf("failed to clean up DNS records: %w", err)
 	}

--- a/cmd/k8zner/handlers/dns_cleanup_test.go
+++ b/cmd/k8zner/handlers/dns_cleanup_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milankappen/k8zner/internal/config"
+	"github.com/milankappen/k8zner/internal/platform/dns"
+)
+
+// fakeDNSProvider records calls so tests can substitute any DNS backend.
+type fakeDNSProvider struct {
+	zoneIDByDomain map[string]string
+	cleanedZoneID  string
+	cleanedOwnerID string
+	cleanupErr     error
+}
+
+func (f *fakeDNSProvider) GetZoneID(_ context.Context, domain string) (string, error) {
+	id, ok := f.zoneIDByDomain[domain]
+	if !ok {
+		return "", fmt.Errorf("zone not found for %s", domain)
+	}
+	return id, nil
+}
+
+func (f *fakeDNSProvider) CleanupClusterRecords(_ context.Context, zoneID, ownerID string) (int, error) {
+	f.cleanedZoneID = zoneID
+	f.cleanedOwnerID = ownerID
+	if f.cleanupErr != nil {
+		return 0, f.cleanupErr
+	}
+	return 2, nil
+}
+
+func TestCleanupCloudflareDNS(t *testing.T) {
+	// Serial: swaps the package-global provider factory shared with other tests.
+	origProvider := newDNSProvider
+	defer func() { newDNSProvider = origProvider }()
+
+	newCfg := func() *config.Config {
+		cfg := &config.Config{ClusterName: "my-cluster"}
+		cfg.Addons.Cloudflare.APIToken = "token"
+		cfg.Addons.Cloudflare.Domain = "example.com"
+		return cfg
+	}
+
+	t.Run("resolves zone by domain and cleans records owned by the cluster", func(t *testing.T) {
+		fake := &fakeDNSProvider{zoneIDByDomain: map[string]string{"example.com": "zone-123"}}
+		newDNSProvider = func(apiToken string) dns.Provider {
+			assert.Equal(t, "token", apiToken)
+			return fake
+		}
+
+		err := cleanupCloudflareDNS(context.Background(), newCfg())
+
+		require.NoError(t, err)
+		assert.Equal(t, "zone-123", fake.cleanedZoneID)
+		assert.Equal(t, "my-cluster", fake.cleanedOwnerID)
+	})
+
+	t.Run("prefers configured zone ID and TXT owner ID", func(t *testing.T) {
+		fake := &fakeDNSProvider{}
+		newDNSProvider = func(string) dns.Provider { return fake }
+
+		cfg := newCfg()
+		cfg.Addons.Cloudflare.ZoneID = "zone-explicit"
+		cfg.Addons.ExternalDNS.TXTOwnerID = "owner-explicit"
+
+		require.NoError(t, cleanupCloudflareDNS(context.Background(), cfg))
+		assert.Equal(t, "zone-explicit", fake.cleanedZoneID)
+		assert.Equal(t, "owner-explicit", fake.cleanedOwnerID)
+	})
+
+	t.Run("zone lookup failure surfaces as error", func(t *testing.T) {
+		newDNSProvider = func(string) dns.Provider {
+			return &fakeDNSProvider{zoneIDByDomain: map[string]string{}}
+		}
+
+		err := cleanupCloudflareDNS(context.Background(), newCfg())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "zone ID")
+	})
+}

--- a/cmd/k8zner/handlers/kubeconfig.go
+++ b/cmd/k8zner/handlers/kubeconfig.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -70,6 +71,19 @@ func generateReadOnlyKubeconfig(ctx context.Context, clientset kubernetes.Interf
 		return nil, err
 	}
 
+	// Merged/managed kubeconfigs often reference the CA by file path rather
+	// than inline data; inline it so the generated kubeconfig is portable.
+	caData := cluster.CertificateAuthorityData
+	if len(caData) == 0 && cluster.CertificateAuthority != "" {
+		caData, err = os.ReadFile(cluster.CertificateAuthority) // #nosec G304 -- path comes from the user's own kubeconfig
+		if err != nil {
+			return nil, fmt.Errorf("failed to read certificate authority file: %w", err)
+		}
+	}
+	if len(caData) == 0 && !cluster.InsecureSkipTLSVerify {
+		return nil, fmt.Errorf("admin kubeconfig has no certificate authority for cluster %q", clusterName)
+	}
+
 	if err := ensureViewerServiceAccount(ctx, clientset); err != nil {
 		return nil, err
 	}
@@ -92,7 +106,8 @@ func generateReadOnlyKubeconfig(ctx context.Context, clientset kubernetes.Interf
 	out := clientcmdapi.NewConfig()
 	out.Clusters[clusterName] = &clientcmdapi.Cluster{
 		Server:                   cluster.Server,
-		CertificateAuthorityData: cluster.CertificateAuthorityData,
+		CertificateAuthorityData: caData,
+		InsecureSkipTLSVerify:    cluster.InsecureSkipTLSVerify,
 	}
 	out.AuthInfos[viewerName] = &clientcmdapi.AuthInfo{
 		Token: tokenReq.Status.Token,

--- a/cmd/k8zner/handlers/kubeconfig.go
+++ b/cmd/k8zner/handlers/kubeconfig.go
@@ -1,0 +1,174 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	// viewerName names the read-only ServiceAccount and its ClusterRoleBinding.
+	viewerName = "k8zner-viewer"
+	// viewerNamespace hosts the viewer ServiceAccount.
+	viewerNamespace = "kube-system"
+)
+
+// Kubeconfig handles the kubeconfig command: it generates a scoped kubeconfig
+// for the cluster. Only read-only generation is supported; the credential is a
+// ServiceAccount token bound to the built-in "view" ClusterRole, which grants
+// no access to Secrets.
+func Kubeconfig(ctx context.Context, adminKubeconfigPath, outputPath string, readOnly bool, ttl time.Duration) error {
+	if !readOnly {
+		return fmt.Errorf("only read-only kubeconfig generation is supported: pass --read-only")
+	}
+
+	adminCfg, err := clientcmd.LoadFromFile(adminKubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load admin kubeconfig from %s: %w", adminKubeconfigPath, err)
+	}
+
+	restCfg, err := clientcmd.NewDefaultClientConfig(*adminCfg, nil).ClientConfig()
+	if err != nil {
+		return fmt.Errorf("failed to build client config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	clusterName := clusterNameFromKubeconfig(adminCfg)
+	out, err := generateReadOnlyKubeconfig(ctx, clientset, adminCfg, clusterName, ttl)
+	if err != nil {
+		return err
+	}
+
+	if err := writeFile(outputPath, out, 0600); err != nil {
+		return fmt.Errorf("failed to write kubeconfig: %w", err)
+	}
+
+	log.Printf("Read-only kubeconfig written to %s (token valid for %s)", outputPath, ttl)
+	return nil
+}
+
+// generateReadOnlyKubeconfig ensures the viewer ServiceAccount and its
+// ClusterRoleBinding exist, requests a bound token, and renders a kubeconfig
+// reusing the server endpoint and CA from the admin kubeconfig.
+func generateReadOnlyKubeconfig(ctx context.Context, clientset kubernetes.Interface, adminCfg *clientcmdapi.Config, clusterName string, ttl time.Duration) ([]byte, error) {
+	cluster, err := currentCluster(adminCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ensureViewerServiceAccount(ctx, clientset); err != nil {
+		return nil, err
+	}
+	if err := ensureViewerClusterRoleBinding(ctx, clientset); err != nil {
+		return nil, err
+	}
+
+	expiration := int64(ttl.Seconds())
+	tokenReq, err := clientset.CoreV1().ServiceAccounts(viewerNamespace).CreateToken(ctx, viewerName,
+		&authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{
+				ExpirationSeconds: &expiration,
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to request token for %s: %w", viewerName, err)
+	}
+
+	contextName := clusterName + "-readonly"
+	out := clientcmdapi.NewConfig()
+	out.Clusters[clusterName] = &clientcmdapi.Cluster{
+		Server:                   cluster.Server,
+		CertificateAuthorityData: cluster.CertificateAuthorityData,
+	}
+	out.AuthInfos[viewerName] = &clientcmdapi.AuthInfo{
+		Token: tokenReq.Status.Token,
+	}
+	out.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  clusterName,
+		AuthInfo: viewerName,
+	}
+	out.CurrentContext = contextName
+
+	rendered, err := clientcmd.Write(*out)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render kubeconfig: %w", err)
+	}
+	return rendered, nil
+}
+
+// currentCluster returns the cluster entry referenced by the current context.
+func currentCluster(cfg *clientcmdapi.Config) (*clientcmdapi.Cluster, error) {
+	kubeCtx, ok := cfg.Contexts[cfg.CurrentContext]
+	if !ok {
+		return nil, fmt.Errorf("admin kubeconfig has no context %q", cfg.CurrentContext)
+	}
+	cluster, ok := cfg.Clusters[kubeCtx.Cluster]
+	if !ok {
+		return nil, fmt.Errorf("admin kubeconfig has no cluster %q", kubeCtx.Cluster)
+	}
+	return cluster, nil
+}
+
+// clusterNameFromKubeconfig derives a display name from the current context.
+func clusterNameFromKubeconfig(cfg *clientcmdapi.Config) string {
+	if kubeCtx, ok := cfg.Contexts[cfg.CurrentContext]; ok && kubeCtx.Cluster != "" {
+		return kubeCtx.Cluster
+	}
+	return "k8zner"
+}
+
+// ensureViewerServiceAccount creates the viewer SA if it does not exist.
+func ensureViewerServiceAccount(ctx context.Context, clientset kubernetes.Interface) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      viewerName,
+			Namespace: viewerNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/managed-by": "k8zner"},
+		},
+	}
+	if _, err := clientset.CoreV1().ServiceAccounts(viewerNamespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create ServiceAccount %s: %w", viewerName, err)
+	}
+	return nil
+}
+
+// ensureViewerClusterRoleBinding binds the viewer SA to the built-in "view"
+// ClusterRole, which deliberately excludes Secrets.
+func ensureViewerClusterRoleBinding(ctx context.Context, clientset kubernetes.Interface) error {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   viewerName,
+			Labels: map[string]string{"app.kubernetes.io/managed-by": "k8zner"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "view",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      viewerName,
+				Namespace: viewerNamespace,
+			},
+		},
+	}
+	if _, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create ClusterRoleBinding %s: %w", viewerName, err)
+	}
+	return nil
+}

--- a/cmd/k8zner/handlers/kubeconfig_test.go
+++ b/cmd/k8zner/handlers/kubeconfig_test.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// newFakeClientsetWithToken returns a fake clientset whose TokenRequest
+// subresource answers with a fixed token.
+func newFakeClientsetWithToken(token string) *fake.Clientset {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "serviceaccounts", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		if action.GetSubresource() != "token" {
+			return false, nil, nil
+		}
+		return true, &authenticationv1.TokenRequest{
+			Status: authenticationv1.TokenRequestStatus{
+				Token:               token,
+				ExpirationTimestamp: metav1.Time{Time: time.Now().Add(time.Hour)},
+			},
+		}, nil
+	})
+	return cs
+}
+
+func adminKubeconfigFixture() *clientcmdapi.Config {
+	return &clientcmdapi.Config{
+		CurrentContext: "admin@my-cluster",
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"my-cluster": {
+				Server:                   "https://203.0.113.10:6443",
+				CertificateAuthorityData: []byte("fake-ca-data"),
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"admin@my-cluster": {Cluster: "my-cluster", AuthInfo: "admin"},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"admin": {ClientCertificateData: []byte("cert"), ClientKeyData: []byte("key")},
+		},
+	}
+}
+
+func TestGenerateReadOnlyKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates viewer service account, binding, and kubeconfig", func(t *testing.T) {
+		t.Parallel()
+		cs := newFakeClientsetWithToken("sa-token-123")
+
+		out, err := generateReadOnlyKubeconfig(context.Background(), cs, adminKubeconfigFixture(), "my-cluster", time.Hour)
+		require.NoError(t, err)
+
+		sa, err := cs.CoreV1().ServiceAccounts(viewerNamespace).Get(context.Background(), viewerName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, viewerName, sa.Name)
+
+		crb, err := cs.RbacV1().ClusterRoleBindings().Get(context.Background(), viewerName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "view", crb.RoleRef.Name)
+		require.Len(t, crb.Subjects, 1)
+		assert.Equal(t, viewerNamespace, crb.Subjects[0].Namespace)
+
+		rendered := string(out)
+		assert.Contains(t, rendered, "sa-token-123")
+		assert.Contains(t, rendered, "https://203.0.113.10:6443")
+		assert.Contains(t, rendered, "my-cluster-readonly")
+	})
+
+	t.Run("idempotent when SA and binding already exist", func(t *testing.T) {
+		t.Parallel()
+		cs := newFakeClientsetWithToken("tok")
+
+		_, err := generateReadOnlyKubeconfig(context.Background(), cs, adminKubeconfigFixture(), "my-cluster", time.Hour)
+		require.NoError(t, err)
+		_, err = generateReadOnlyKubeconfig(context.Background(), cs, adminKubeconfigFixture(), "my-cluster", time.Hour)
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when admin kubeconfig has no current cluster", func(t *testing.T) {
+		t.Parallel()
+		cs := newFakeClientsetWithToken("tok")
+		broken := adminKubeconfigFixture()
+		broken.CurrentContext = "missing"
+
+		_, err := generateReadOnlyKubeconfig(context.Background(), cs, broken, "my-cluster", time.Hour)
+		require.Error(t, err)
+	})
+}
+
+func TestWriteReadOnlyKubeconfig_FilePermissions(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not meaningful on windows")
+	}
+
+	cs := newFakeClientsetWithToken("tok")
+	out, err := generateReadOnlyKubeconfig(context.Background(), cs, adminKubeconfigFixture(), "my-cluster", time.Hour)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "kubeconfig-readonly")
+	require.NoError(t, writeFile(path, out, 0600))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(data), "tok"))
+}

--- a/cmd/k8zner/handlers/kubeconfig_test.go
+++ b/cmd/k8zner/handlers/kubeconfig_test.go
@@ -102,6 +102,32 @@ func TestGenerateReadOnlyKubeconfig(t *testing.T) {
 	})
 }
 
+func TestGenerateReadOnlyKubeconfig_CAFromFile(t *testing.T) {
+	t.Parallel()
+
+	caPath := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(caPath, []byte("file-ca-data"), 0o600))
+
+	adminCfg := adminKubeconfigFixture()
+	adminCfg.Clusters["my-cluster"].CertificateAuthorityData = nil
+	adminCfg.Clusters["my-cluster"].CertificateAuthority = caPath
+
+	out, err := generateReadOnlyKubeconfig(context.Background(), newFakeClientsetWithToken("tok"), adminCfg, "my-cluster", time.Hour)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "ZmlsZS1jYS1kYXRh", "CA file contents must be inlined as base64")
+}
+
+func TestGenerateReadOnlyKubeconfig_NoCAErrors(t *testing.T) {
+	t.Parallel()
+
+	adminCfg := adminKubeconfigFixture()
+	adminCfg.Clusters["my-cluster"].CertificateAuthorityData = nil
+
+	_, err := generateReadOnlyKubeconfig(context.Background(), newFakeClientsetWithToken("tok"), adminCfg, "my-cluster", time.Hour)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate authority")
+}
+
 func TestWriteReadOnlyKubeconfig_FilePermissions(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -71,8 +72,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Get credentials from environment or secrets
-	hcloudToken := os.Getenv("HCLOUD_TOKEN")
+	// Get credentials from environment or secrets. Trim whitespace because
+	// secrets created with `kubectl create secret --from-file` often carry a
+	// trailing newline, which would make every Hetzner API call fail with 401.
+	hcloudToken := strings.TrimSpace(os.Getenv("HCLOUD_TOKEN"))
 	if hcloudToken == "" {
 		setupLog.Error(nil, "HCLOUD_TOKEN environment variable is required")
 		os.Exit(1)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -109,20 +109,34 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	switch logLevel {
-	case "debug":
-		opts.Development = true
-		opts.Level = zapcore.DebugLevel
-	case "info":
-		opts.Level = zapcore.InfoLevel
-	case "error":
-		opts.Level = zapcore.ErrorLevel
-	default:
-		setupLog.Error(nil, "invalid --log-level, must be debug, info, or error", "value", logLevel)
-		os.Exit(1)
+	setFlags := map[string]bool{}
+	flag.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
+
+	// Explicitly-passed zap flags stay authoritative; --log-level only fills
+	// in when they are absent. Unknown values fall back to info instead of
+	// exiting: a values.yaml typo must not crash-loop the operator that
+	// self-heals the cluster it runs on.
+	invalidLevel := false
+	if !setFlags["zap-log-level"] && !setFlags["zap-devel"] {
+		switch logLevel {
+		case "debug":
+			opts.Development = true
+			opts.Level = zapcore.DebugLevel
+		case "info":
+			opts.Level = zapcore.InfoLevel
+		case "error":
+			opts.Level = zapcore.ErrorLevel
+		default:
+			invalidLevel = true
+			opts.Level = zapcore.InfoLevel
+		}
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if invalidLevel {
+		setupLog.Error(nil, "invalid --log-level, using info (valid: debug, info, error)", "value", logLevel)
+	}
 
 	setupLog.Info("starting k8zner-operator", "version", Version)
 
@@ -130,9 +144,11 @@ func main() {
 
 	// Self-apply the CRD before the manager starts so the served schema
 	// always matches this binary (Helm never upgrades chart crds/).
+	// Non-fatal: operators deployed before the apiextensions RBAC existed
+	// would otherwise crash-loop on upgrade; they can still reconcile
+	// against the already-installed CRD.
 	if err := ensureCRDs(restConfig); err != nil {
-		setupLog.Error(err, "unable to ensure CRDs")
-		os.Exit(1)
+		setupLog.Error(err, "unable to self-apply CRDs; continuing with the schema already installed")
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -3,8 +3,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
+
+	"go.uber.org/zap/zapcore"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -31,24 +34,69 @@ func init() {
 	utilruntime.Must(k8znerv1alpha1.AddToScheme(scheme))
 }
 
+// loadHCloudToken reads the Hetzner Cloud API token from the file named by
+// HCLOUD_TOKEN_FILE (preferred: a mounted Secret volume keeps the token out of
+// the pod's environment and `kubectl describe` output), falling back to the
+// HCLOUD_TOKEN environment variable. Whitespace is trimmed because secrets
+// created with `kubectl create secret --from-file` often carry a trailing
+// newline, which would make every Hetzner API call fail with 401.
+func loadHCloudToken() (string, error) {
+	if path := os.Getenv("HCLOUD_TOKEN_FILE"); path != "" {
+		data, err := os.ReadFile(path) // #nosec G304 -- path is operator config, not user input
+		if err != nil {
+			return "", fmt.Errorf("failed to read HCLOUD_TOKEN_FILE: %w", err)
+		}
+		token := strings.TrimSpace(string(data))
+		if token == "" {
+			return "", fmt.Errorf("token file %s is empty", path)
+		}
+		return token, nil
+	}
+
+	token := strings.TrimSpace(os.Getenv("HCLOUD_TOKEN"))
+	if token == "" {
+		return "", fmt.Errorf("either HCLOUD_TOKEN_FILE or HCLOUD_TOKEN must be set")
+	}
+	return token, nil
+}
+
 func main() {
 	var (
 		metricsAddr          string
 		probeAddr            string
 		enableLeaderElection bool
 		leaderElectionID     string
+		logLevel             string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true, "Enable leader election for controller manager.")
 	flag.StringVar(&leaderElectionID, "leader-election-id", "k8zner-operator", "The name of the leader election resource.")
+	flag.StringVar(&logLevel, "log-level", "info", "Log verbosity: debug, info, or error.")
 
-	opts := zap.Options{
-		Development: os.Getenv("DEBUG") == "true",
+	// DEBUG=true is the legacy switch, kept so existing deployments don't
+	// silently lose debug output when upgrading.
+	if os.Getenv("DEBUG") == "true" {
+		logLevel = "debug"
 	}
+
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	switch logLevel {
+	case "debug":
+		opts.Development = true
+		opts.Level = zapcore.DebugLevel
+	case "info":
+		opts.Level = zapcore.InfoLevel
+	case "error":
+		opts.Level = zapcore.ErrorLevel
+	default:
+		setupLog.Error(nil, "invalid --log-level, must be debug, info, or error", "value", logLevel)
+		os.Exit(1)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -72,12 +120,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Get credentials from environment or secrets. Trim whitespace because
-	// secrets created with `kubectl create secret --from-file` often carry a
-	// trailing newline, which would make every Hetzner API call fail with 401.
-	hcloudToken := strings.TrimSpace(os.Getenv("HCLOUD_TOKEN"))
-	if hcloudToken == "" {
-		setupLog.Error(nil, "HCLOUD_TOKEN environment variable is required")
+	hcloudToken, err := loadHCloudToken()
+	if err != nil {
+		setupLog.Error(err, "unable to load Hetzner Cloud token")
 		os.Exit(1)
 	}
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -2,23 +2,29 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"go.uber.org/zap/zapcore"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
 	"github.com/milankappen/k8zner/internal/operator/controller"
+	"github.com/milankappen/k8zner/internal/operator/crds"
 )
 
 var (
@@ -32,6 +38,24 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(k8znerv1alpha1.AddToScheme(scheme))
+}
+
+// ensureCRDs server-side-applies the operator's embedded CRDs with a direct
+// (uncached) client, bounded so a hung apiserver cannot stall startup forever.
+func ensureCRDs(restConfig *rest.Config) error {
+	s := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(s); err != nil {
+		return fmt.Errorf("failed to register apiextensions scheme: %w", err)
+	}
+
+	directClient, err := client.New(restConfig, client.Options{Scheme: s})
+	if err != nil {
+		return fmt.Errorf("failed to create client for CRD apply: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return crds.Ensure(ctx, directClient)
 }
 
 // loadHCloudToken reads the Hetzner Cloud API token from the file named by
@@ -102,7 +126,16 @@ func main() {
 
 	setupLog.Info("starting k8zner-operator", "version", Version)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+
+	// Self-apply the CRD before the manager starts so the served schema
+	// always matches this binary (Helm never upgrades chart crds/).
+	if err := ensureCRDs(restConfig); err != nil {
+		setupLog.Error(err, "unable to ensure CRDs")
+		os.Exit(1)
+	}
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadHCloudToken(t *testing.T) {
+	t.Run("reads token from file when HCLOUD_TOKEN_FILE is set", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		if err := os.WriteFile(path, []byte("file-token\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("HCLOUD_TOKEN_FILE", path)
+		t.Setenv("HCLOUD_TOKEN", "env-token")
+
+		token, err := loadHCloudToken()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "file-token" {
+			t.Errorf("expected trimmed file token to win over env, got %q", token)
+		}
+	})
+
+	t.Run("falls back to trimmed env var", func(t *testing.T) {
+		t.Setenv("HCLOUD_TOKEN_FILE", "")
+		t.Setenv("HCLOUD_TOKEN", "  env-token\n")
+
+		token, err := loadHCloudToken()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "env-token" {
+			t.Errorf("expected trimmed env token, got %q", token)
+		}
+	})
+
+	t.Run("errors when token file is missing", func(t *testing.T) {
+		t.Setenv("HCLOUD_TOKEN_FILE", filepath.Join(t.TempDir(), "missing"))
+		t.Setenv("HCLOUD_TOKEN", "env-token")
+
+		if _, err := loadHCloudToken(); err == nil {
+			t.Error("expected error for missing token file")
+		}
+	})
+
+	t.Run("errors when token file is empty", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "token")
+		if err := os.WriteFile(path, []byte("  \n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("HCLOUD_TOKEN_FILE", path)
+
+		if _, err := loadHCloudToken(); err == nil {
+			t.Error("expected error for empty token file")
+		}
+	})
+
+	t.Run("errors when nothing is set", func(t *testing.T) {
+		t.Setenv("HCLOUD_TOKEN_FILE", "")
+		t.Setenv("HCLOUD_TOKEN", "")
+
+		if _, err := loadHCloudToken(); err == nil {
+			t.Error("expected error when no token source is configured")
+		}
+	})
+}

--- a/config/crd/bases/k8zner.io_k8znerclusters.yaml
+++ b/config/crd/bases/k8zner.io_k8znerclusters.yaml
@@ -94,6 +94,12 @@ spec:
                     default: true
                     description: Traefik ingress controller
                     type: boolean
+                  wildcardCertificate:
+                    description: |-
+                      WildcardCertificate additionally issues a "*.{domain}" certificate via
+                      DNS01 and sets it as Traefik's default certificate, so ingresses
+                      without an explicit TLS secret are covered. Requires domain.
+                    type: boolean
                 type: object
               backup:
                 description: Backup configures automated etcd backups

--- a/config/crd/bases/k8zner.io_k8znerclusters.yaml
+++ b/config/crd/bases/k8zner.io_k8znerclusters.yaml
@@ -62,6 +62,8 @@ spec:
                     description: |-
                       ArgoSubdomain overrides the default "argo" subdomain for ArgoCD ingress.
                       The full host will be "{argoSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
                   argocd:
                     description: ArgoCD for GitOps
@@ -77,6 +79,8 @@ spec:
                     description: |-
                       GrafanaSubdomain overrides the default "grafana" subdomain for Grafana ingress.
                       The full host will be "{grafanaSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
                   metricsServer:
                     default: true
@@ -163,7 +167,7 @@ spec:
                   size:
                     default: cx23
                     description: |-
-                      Size is the Hetzner server type (e.g., cx23, cx33, cpx21, cpx31)
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
                       CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
                     type: string
                 required:
@@ -171,8 +175,10 @@ spec:
                 - size
                 type: object
               credentialsRef:
-                description: CredentialsRef references the Secret containing HCloud
-                  token and Talos secrets
+                description: |-
+                  CredentialsRef references the Secret containing HCloud token and Talos secrets.
+                  Once set, it cannot be changed or removed: swapping credentials mid-lifecycle
+                  would silently re-point provisioning at a different Hetzner project.
                 properties:
                   name:
                     default: ""
@@ -185,10 +191,16 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: credentialsRef is immutable once set
+                  rule: '!has(oldSelf.name) || oldSelf.name == "" || (has(self.name)
+                    && self.name == oldSelf.name)'
               domain:
                 description: |-
                   Domain is the base domain for ingress resources (e.g., "example.com").
                   When set, addons like ArgoCD and Grafana will have ingress automatically configured.
+                maxLength: 253
+                pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$
                 type: string
               firewall:
                 description: Firewall configures the cluster firewall rules
@@ -271,6 +283,9 @@ spec:
                 - nbg1
                 - hel1
                 type: string
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: self == oldSelf
               talos:
                 description: Talos specifies the Talos configuration
                 properties:
@@ -302,7 +317,7 @@ spec:
                   size:
                     default: cx23
                     description: |-
-                      Size is the Hetzner server type (e.g., cx23, cx33, cpx21, cpx31)
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
                       CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
                     type: string
                 required:
@@ -496,8 +511,8 @@ spec:
                       description: NodeStatus represents the status of a single node.
                       properties:
                         healthy:
-                          description: Healthy indicates if the node is healthy (deprecated,
-                            use Phase)
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
                           type: boolean
                         lastHealthCheck:
                           description: LastHealthCheck is when health was last checked
@@ -724,8 +739,8 @@ spec:
                       description: NodeStatus represents the status of a single node.
                       properties:
                         healthy:
-                          description: Healthy indicates if the node is healthy (deprecated,
-                            use Phase)
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
                           type: boolean
                         lastHealthCheck:
                           description: LastHealthCheck is when health was last checked

--- a/config/crd/bases/k8zner.io_k8znerclusters.yaml
+++ b/config/crd/bases/k8zner.io_k8znerclusters.yaml
@@ -82,6 +82,10 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
+                  logging:
+                    description: Logging enables the Loki + Alloy log aggregation
+                      stack
+                    type: boolean
                   metricsServer:
                     default: true
                     description: MetricsServer for resource metrics

--- a/deploy/crds/k8zner.io_k8znerclusters.yaml
+++ b/deploy/crds/k8zner.io_k8znerclusters.yaml
@@ -94,6 +94,12 @@ spec:
                     default: true
                     description: Traefik ingress controller
                     type: boolean
+                  wildcardCertificate:
+                    description: |-
+                      WildcardCertificate additionally issues a "*.{domain}" certificate via
+                      DNS01 and sets it as Traefik's default certificate, so ingresses
+                      without an explicit TLS secret are covered. Requires domain.
+                    type: boolean
                 type: object
               backup:
                 description: Backup configures automated etcd backups

--- a/deploy/crds/k8zner.io_k8znerclusters.yaml
+++ b/deploy/crds/k8zner.io_k8znerclusters.yaml
@@ -62,6 +62,8 @@ spec:
                     description: |-
                       ArgoSubdomain overrides the default "argo" subdomain for ArgoCD ingress.
                       The full host will be "{argoSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
                   argocd:
                     description: ArgoCD for GitOps
@@ -77,6 +79,8 @@ spec:
                     description: |-
                       GrafanaSubdomain overrides the default "grafana" subdomain for Grafana ingress.
                       The full host will be "{grafanaSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
                   metricsServer:
                     default: true
@@ -163,7 +167,7 @@ spec:
                   size:
                     default: cx23
                     description: |-
-                      Size is the Hetzner server type (e.g., cx23, cx33, cpx21, cpx31)
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
                       CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
                     type: string
                 required:
@@ -171,8 +175,10 @@ spec:
                 - size
                 type: object
               credentialsRef:
-                description: CredentialsRef references the Secret containing HCloud
-                  token and Talos secrets
+                description: |-
+                  CredentialsRef references the Secret containing HCloud token and Talos secrets.
+                  Once set, it cannot be changed or removed: swapping credentials mid-lifecycle
+                  would silently re-point provisioning at a different Hetzner project.
                 properties:
                   name:
                     default: ""
@@ -185,10 +191,16 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: credentialsRef is immutable once set
+                  rule: '!has(oldSelf.name) || oldSelf.name == "" || (has(self.name)
+                    && self.name == oldSelf.name)'
               domain:
                 description: |-
                   Domain is the base domain for ingress resources (e.g., "example.com").
                   When set, addons like ArgoCD and Grafana will have ingress automatically configured.
+                maxLength: 253
+                pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$
                 type: string
               firewall:
                 description: Firewall configures the cluster firewall rules
@@ -271,6 +283,9 @@ spec:
                 - nbg1
                 - hel1
                 type: string
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: self == oldSelf
               talos:
                 description: Talos specifies the Talos configuration
                 properties:
@@ -302,7 +317,7 @@ spec:
                   size:
                     default: cx23
                     description: |-
-                      Size is the Hetzner server type (e.g., cx23, cx33, cpx21, cpx31)
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
                       CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
                     type: string
                 required:
@@ -496,8 +511,8 @@ spec:
                       description: NodeStatus represents the status of a single node.
                       properties:
                         healthy:
-                          description: Healthy indicates if the node is healthy (deprecated,
-                            use Phase)
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
                           type: boolean
                         lastHealthCheck:
                           description: LastHealthCheck is when health was last checked
@@ -724,8 +739,8 @@ spec:
                       description: NodeStatus represents the status of a single node.
                       properties:
                         healthy:
-                          description: Healthy indicates if the node is healthy (deprecated,
-                            use Phase)
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
                           type: boolean
                         lastHealthCheck:
                           description: LastHealthCheck is when health was last checked

--- a/deploy/crds/k8zner.io_k8znerclusters.yaml
+++ b/deploy/crds/k8zner.io_k8znerclusters.yaml
@@ -82,6 +82,10 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
+                  logging:
+                    description: Logging enables the Loki + Alloy log aggregation
+                      stack
+                    type: boolean
                   metricsServer:
                     default: true
                     description: MetricsServer for resource metrics

--- a/deploy/helm/k8zner-operator/templates/deployment.yaml
+++ b/deploy/helm/k8zner-operator/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "k8zner-operator.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -44,6 +47,7 @@ spec:
           args:
             - --metrics-bind-address=:{{ .Values.metrics.port }}
             - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+            - --log-level={{ .Values.logLevel }}
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect=true
             - --leader-election-id={{ .Values.leaderElection.resourceName }}
@@ -51,15 +55,10 @@ spec:
             - --leader-elect=false
             {{- end }}
           env:
-            - name: HCLOUD_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "k8zner-operator.credentialsSecretName" . }}
-                  key: {{ .Values.credentials.existingSecretKey }}
-            {{- if eq .Values.logLevel "debug" }}
-            - name: DEBUG
-              value: "true"
-            {{- end }}
+            # The token is mounted as a file rather than injected as an env var
+            # so it never shows up in `kubectl describe pod` or env dumps.
+            - name: HCLOUD_TOKEN_FILE
+              value: /var/run/secrets/k8zner/{{ .Values.credentials.existingSecretKey }}
             {{- if .Values.hostNetwork }}
             - name: KUBERNETES_SERVICE_HOST
               value: "localhost"
@@ -88,6 +87,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            - name: credentials
+              mountPath: /var/run/secrets/k8zner
+              readOnly: true
             - name: helm-cache
               mountPath: /home/nonroot/.cache
             - name: helm-config
@@ -95,6 +97,10 @@ spec:
             - name: tmp
               mountPath: /tmp
       volumes:
+        - name: credentials
+          secret:
+            secretName: {{ include "k8zner-operator.credentialsSecretName" . }}
+            defaultMode: 288 # 0440 in decimal; YAML 1.2 parsers read 0440 as decimal 440
         - name: helm-cache
           emptyDir: {}
         - name: helm-config

--- a/deploy/helm/k8zner-operator/templates/networkpolicy.yaml
+++ b/deploy/helm/k8zner-operator/templates/networkpolicy.yaml
@@ -1,0 +1,53 @@
+{{- /*
+NetworkPolicies do not apply to hostNetwork pods, so skip rendering when the
+operator runs in hostNetwork mode (e.g. before CNI is installed).
+*/}}
+{{- if and .Values.networkPolicy.enabled (not .Values.hostNetwork) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "k8zner-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8zner-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "k8zner-operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow metrics scraping and health probes from anywhere in-cluster.
+    # Kubelet probes originate from the node itself, which NetworkPolicy
+    # cannot select reliably, so no `from` restriction is applied; all
+    # other ingress is denied because this policy selects the pod.
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.metrics.port }}
+        - protocol: TCP
+          port: {{ .Values.healthProbe.port }}
+  egress:
+    # DNS resolution (CoreDNS and upstream resolvers).
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # The Hetzner Cloud API, Helm chart repositories, ghcr.io, the Kubernetes
+    # apiserver, and the Talos API on cluster nodes are all outside the
+    # cluster network, so they cannot be selected more precisely than by CIDR:
+    #   - 443:   HTTPS (Hetzner Cloud API, chart repos, ghcr.io, apiserver LB)
+    #   - 6443:  Kubernetes apiserver
+    #   - 50000: Talos API on cluster nodes
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 50000
+{{- end }}

--- a/deploy/helm/k8zner-operator/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/k8zner-operator/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "k8zner-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8zner-operator.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "k8zner-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/k8zner-operator/templates/rbac.yaml
+++ b/deploy/helm/k8zner-operator/templates/rbac.yaml
@@ -19,6 +19,14 @@ metadata:
   labels:
     {{- include "k8zner-operator.labels" . | nindent 4 }}
 rules:
+  # CRD self-apply at startup (create cannot be scoped by resourceNames)
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["k8znerclusters.k8zner.io"]
+    verbs: ["get", "update", "patch"]
   # K8znerCluster CRD
   - apiGroups: ["k8zner.io"]
     resources: ["k8znerclusters"]

--- a/deploy/helm/k8zner-operator/values.yaml
+++ b/deploy/helm/k8zner-operator/values.yaml
@@ -33,8 +33,22 @@ credentials:
 podAnnotations: {}
 podLabels: {}
 
+# Priority class for the operator pods. The operator self-heals the cluster it
+# runs on, so consider "system-cluster-critical" to protect it from eviction
+# under node pressure. Empty means no priority class.
+priorityClassName: ""
+
+# Keep at least one operator replica available during voluntary disruptions
+# (node drains, upgrades). Only rendered when replicaCount > 1.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
 podSecurityContext:
   runAsNonRoot: true
+  # Group-own mounted volumes (the credentials secret) so the nonroot user
+  # can read them with a restrictive file mode.
+  fsGroup: 65532
   seccompProfile:
     type: RuntimeDefault
 

--- a/deploy/helm/k8zner-operator/values.yaml
+++ b/deploy/helm/k8zner-operator/values.yaml
@@ -115,5 +115,11 @@ metrics:
 healthProbe:
   port: 8081
 
+# NetworkPolicy restricting the operator pod to the traffic it needs.
+# Not rendered when hostNetwork is enabled, because NetworkPolicies do not
+# apply to hostNetwork pods.
+networkPolicy:
+  enabled: true
+
 # Log level (debug, info, error)
 logLevel: info

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,33 @@ When set, this automatically enables:
 
 Requires `CF_API_TOKEN` environment variable.
 
+### wildcard_certificate (optional)
+
+Issue a single wildcard certificate for `*.{domain}` instead of per-host
+certificates, and make it Traefik's default.
+
+```yaml
+domain: example.com
+wildcard_certificate: true
+```
+
+Any ingress under the domain that does not name its own TLS secret is then
+served with the wildcard certificate. Ingresses with an explicit TLS secret
+are unaffected. Requires `domain`.
+
+### logging (optional)
+
+Install the log aggregation stack: Loki (single binary, persisted on a
+Hetzner volume, 7-day retention) plus Grafana Alloy as the collector.
+
+```yaml
+logging: true
+```
+
+Alloy tails pod logs through the Kubernetes API — no privileged host mounts.
+When `monitoring` is also enabled, Loki is registered as a Grafana datasource
+automatically.
+
 ### cert_email (optional)
 
 Email address for Let's Encrypt certificate expiration notifications.

--- a/docs/design/adr-004-api-v1beta1.md
+++ b/docs/design/adr-004-api-v1beta1.md
@@ -1,0 +1,93 @@
+# ADR-004: K8znerCluster API maturity and the path to v1beta1
+
+## Status
+
+Accepted (plan) — implementation deferred until a second API consumer exists.
+
+## Context
+
+`k8zner.io/v1alpha1` is becoming a contract: the CLI writes it, the operator
+reconciles it, and any future client (web UI, GitOps pipelines, additional
+CLIs) will read and write it. Several decisions made during v1alpha1 need a
+deliberate cleanup before more clients build on the API, because changing
+them later multiplies the migration cost.
+
+### What is wrong with v1alpha1
+
+1. **State lives in spec.** `spec.bootstrap` (`BootstrapState`: `completed`,
+   `completedAt`, `bootstrapNode`, `bootstrapNodeID`, ...) is observed state
+   written by the CLI after bootstrap, not desired state declared by a user.
+   This breaks GitOps round-tripping: a cluster manifest checked into git
+   (without the bootstrap block) permanently diffs against the live object,
+   and ArgoCD-style sync would strip the operator's view of bootstrap
+   progress. Kubernetes API conventions are explicit that spec is desired
+   state and status is observed state.
+
+2. **`spec.workers.count` is also mutated by external actors** (scaling), but
+   that one is legitimate desired state — users edit it. No change needed;
+   noted here because it is the counterexample that makes `spec.bootstrap`
+   clearly wrong.
+
+### What is already in place (do not redo)
+
+- Standard `metav1.Condition` usage with a top-level `Ready` condition, plus
+  `ControlPlaneReady`, `WorkersReady`, `AddonsHealthy`,
+  `InfrastructureReady`, `ImageReady`, `Bootstrapped`, and `UpToDate`
+  (version-skew detection). Clients should key off conditions, not phases.
+- CEL validation: `region` immutable, `credentialsRef` immutable once set,
+  DNS-shaped validation for `domain` and subdomains.
+- `status.observedGeneration`, phase history, addon version tracking.
+- The operator self-applies its CRD at startup, so schema rollout is tied to
+  the operator version, not the install method.
+
+## Decision
+
+### v1beta1 shape (the breaking changes worth making, all at once)
+
+1. Move bootstrap state to status: `status.bootstrap` mirrors today's
+   `BootstrapState`. The CLI records bootstrap completion via the status
+   subresource instead of patching spec.
+2. Drop `spec.bootstrap` from v1beta1. During conversion (see below) the
+   value is carried over into status.
+3. No other field renames: everything else in v1alpha1 has held up.
+
+### Conversion and rollout strategy
+
+We deliberately avoid a conversion webhook (operational cost: serving certs,
+availability coupling, upgrade ordering). Instead:
+
+1. v1beta1 is added as a new served version; v1alpha1 stays served and
+   remains the **storage** version initially. Schemas are identical except
+   for the bootstrap relocation, so round-trip without a webhook is possible
+   only if we keep `spec.bootstrap` present-but-deprecated in v1beta1 for one
+   release. That is the plan:
+   - Release N: introduce v1beta1 (served, not storage) with
+     `spec.bootstrap` marked deprecated and `status.bootstrap` authoritative.
+     The operator reads both, writes status only. The CLI switches to
+     creating v1beta1 objects and writing status.
+   - Release N+1: flip storage to v1beta1; run the storage-version migration
+     (touch every object once — the operator does this at startup, mirroring
+     the CRD self-apply step).
+   - Release N+2: drop `spec.bootstrap` from the v1beta1 schema and stop
+     serving v1alpha1.
+2. The operator's CRD self-apply makes each step a pure operator upgrade; no
+   manual kubectl steps for users.
+
+### Compatibility commitments starting now
+
+- New spec fields must be optional with safe defaults; new validation must be
+  CEL (no admission webhooks).
+- Status is the only side the operator writes; the single existing violation
+  (the operator currently flips nothing in spec — only the CLI writes
+  `spec.bootstrap`) must not grow.
+- Condition types are append-only; reasons are part of the contract for UIs.
+
+## Consequences
+
+- Until v1beta1 lands, GitOps users must omit-and-ignore `spec.bootstrap`
+  (e.g. ArgoCD `ignoreDifferences`). Documented limitation.
+- The three-release rollout is slower than a webhook conversion but keeps the
+  operator dependency-free and single-binary, which matches the project's
+  maintainability goals.
+- A future multi-user control plane (web UI) builds on v1beta1 conditions
+  and the status subresource without any further API rework.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -69,6 +69,36 @@ This process is fully automatic. Monitor via:
 kubectl get events -n k8zner-system | grep -i "control-plane\|healing\|quorum"
 ```
 
+## Addon Upgrades
+
+The operator keeps addons converged on the chart versions pinned in the
+running operator release. When you upgrade the operator, outdated addons are
+re-rendered and re-applied one at a time, only while every desired node is
+ready, with events (`AddonUpgrading`, `AddonUpgraded`, `AddonUpgradeFailed`)
+and per-addon versions visible in `status.addons`. Addons enabled in the spec
+after provisioning are installed the same way.
+
+Cilium is deliberately excluded from automatic upgrades: CNI upgrades affect
+every pod on the cluster and remain a manual operation.
+
+The `UpToDate` condition reports Kubernetes version skew: if any node's
+kubelet does not match `spec.kubernetes.version`, the condition turns False
+with an `UpgradePending` event. The operator never replaces nodes for version
+reasons — run `k8zner apply` to roll out node upgrades.
+
+## Sharing Read-Only Access
+
+Generate a kubeconfig scoped to the built-in `view` ClusterRole (no access to
+Secrets):
+
+```bash
+k8zner kubeconfig --read-only                 # token valid 1 year
+k8zner kubeconfig --read-only --duration 720h -o ./readonly.yaml
+```
+
+The credential is a ServiceAccount token; revoke access by deleting the
+`k8zner-viewer` ClusterRoleBinding.
+
 ## Upgrading Kubernetes
 
 k8zner pins Kubernetes and Talos versions in its version matrix. To upgrade:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -233,6 +233,17 @@ This removes all Hetzner Cloud resources (servers, networks, firewalls, load bal
 
 **Warning**: This is irreversible. Ensure you have backups if needed.
 
+### Why `kubectl delete k8znercluster` does not destroy infrastructure
+
+Deleting the `K8znerCluster` resource intentionally leaves all cloud
+infrastructure intact — there is no finalizer that tears down Hetzner
+resources. This is a deliberate design decision, not an omission: the
+operator runs *inside* the cluster it manages, so a finalizer-driven
+teardown would delete the servers the operator itself runs on partway
+through cleanup, reliably leaving half-deleted infrastructure behind with
+nothing left to finish the job. Always tear down clusters from outside
+with `k8zner destroy` (or the `cleanup` utility for orphaned resources).
+
 ## Talos Administration
 
 k8zner clusters run Talos Linux. Common Talos operations:

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.20.2
 	k8s.io/api v0.35.4
+	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 	sigs.k8s.io/controller-runtime v0.23.3
@@ -192,7 +193,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.4 // indirect
 	k8s.io/cli-runtime v0.35.4 // indirect
 	k8s.io/component-base v0.35.4 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/siderolabs/talos/pkg/machinery v1.12.6
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.52.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.20.2
@@ -171,7 +172,6 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect

--- a/internal/addons/argocd.go
+++ b/internal/addons/argocd.go
@@ -28,7 +28,7 @@ func applyArgoCD(ctx context.Context, client k8sclient.Client, cfg *config.Confi
 		}
 	}
 
-	if err := ensureNamespace(ctx, client, "argocd", map[string]string{"name": "argocd"}); err != nil {
+	if err := ensureNamespace(ctx, client, "argocd", withBaselinePodSecurity(map[string]string{"name": "argocd"})); err != nil {
 		return err
 	}
 

--- a/internal/addons/argocd_test.go
+++ b/internal/addons/argocd_test.go
@@ -386,11 +386,14 @@ func TestBuildArgoCDRedis(t *testing.T) {
 
 func TestArgoCDNamespace(t *testing.T) {
 	t.Parallel()
-	ns := helm.NamespaceManifest("argocd", map[string]string{"name": "argocd"})
+	ns := helm.NamespaceManifest("argocd", withBaselinePodSecurity(map[string]string{"name": "argocd"}))
 
 	assert.Contains(t, ns, "apiVersion: v1")
 	assert.Contains(t, ns, "kind: Namespace")
 	assert.Contains(t, ns, "name: argocd")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/enforce: baseline")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/audit: baseline")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/warn: baseline")
 }
 
 func TestBuildArgoCDValuesCustomHelmValues(t *testing.T) {

--- a/internal/addons/cert_manager.go
+++ b/internal/addons/cert_manager.go
@@ -10,7 +10,7 @@ import (
 
 // applyCertManager installs cert-manager for TLS certificate management.
 func applyCertManager(ctx context.Context, client k8sclient.Client, cfg *config.Config) error {
-	if err := ensureNamespace(ctx, client, "cert-manager", nil); err != nil {
+	if err := ensureNamespace(ctx, client, "cert-manager", withBaselinePodSecurity(nil)); err != nil {
 		return err
 	}
 

--- a/internal/addons/cert_manager_cloudflare.go
+++ b/internal/addons/cert_manager_cloudflare.go
@@ -58,30 +58,56 @@ func applyCertManagerCloudflare(ctx context.Context, client k8sclient.Client, cf
 		log.Println("Skipping production ClusterIssuer (no email provided - staging certificates only)")
 	}
 
-	// Wildcard certificate: one DNS01 cert for the whole domain, set as
-	// Traefik's default so ingresses without an explicit TLS secret are
-	// covered. Existing ingresses that name their own secret are unaffected.
-	if cfCfg.WildcardCertificate && cfg.Addons.Cloudflare.Domain != "" {
-		issuerName := "letsencrypt-cloudflare-staging"
-		if cfCfg.Email != "" {
-			issuerName = "letsencrypt-cloudflare-production"
-		}
+	return nil
+}
 
-		manifest, err := buildWildcardCertManifest(cfg.Addons.Cloudflare.Domain, issuerName)
-		if err != nil {
-			return fmt.Errorf("failed to build wildcard certificate manifest: %w", err)
-		}
+// cloudflareIssuerName returns the ClusterIssuer that applyCertManagerCloudflare
+// created: production when an email is configured, otherwise staging only.
+func cloudflareIssuerName(cfCfg config.CertManagerCloudflareConfig) string {
+	if cfCfg.Email != "" {
+		return "letsencrypt-cloudflare-production"
+	}
+	return "letsencrypt-cloudflare-staging"
+}
 
-		// cert-manager installs before traefik, so the namespace may not exist yet.
-		if err := ensureNamespace(ctx, client, "traefik", baselinePodSecurityLabels); err != nil {
-			return err
-		}
-		if err := applyManifests(ctx, client, "wildcard-certificate", manifest); err != nil {
-			return fmt.Errorf("failed to apply wildcard certificate: %w", err)
-		}
-		log.Printf("Wildcard certificate for *.%s requested via %s", cfg.Addons.Cloudflare.Domain, issuerName)
+// applyWildcardCertificate requests one DNS01 certificate for "*.{domain}" and
+// makes it Traefik's default via a TLSStore, so ingresses without an explicit
+// TLS secret are covered. It must run in the traefik step: the TLSStore CRD
+// ships with the Traefik chart, which installs after cert-manager.
+func applyWildcardCertificate(ctx context.Context, client k8sclient.Client, cfg *config.Config) error {
+	cfCfg := cfg.Addons.CertManager.Cloudflare
+	domain := cfg.Addons.Cloudflare.Domain
+	if !cfCfg.WildcardCertificate || domain == "" {
+		return nil
 	}
 
+	issuerName := cloudflareIssuerName(cfCfg)
+	certManifest, err := buildWildcardCertManifest(domain, issuerName)
+	if err != nil {
+		return fmt.Errorf("failed to build wildcard certificate manifest: %w", err)
+	}
+	if err := applyManifests(ctx, client, "wildcard-certificate", certManifest); err != nil {
+		return fmt.Errorf("failed to apply wildcard certificate: %w", err)
+	}
+	log.Printf("Wildcard certificate for *.%s requested via %s", domain, issuerName)
+
+	// The TLSStore CRD was installed by the Traefik chart moments ago; give
+	// discovery a moment to catch up. If it never appears (e.g. a custom
+	// chart without CRDs), degrade to a warning instead of failing the step:
+	// the certificate above still exists for explicit ingress TLS use.
+	if err := waitForResource(ctx, func(ctx context.Context) (bool, error) {
+		return client.HasCRD(ctx, "traefik.io/v1alpha1/TLSStore")
+	}, DefaultResourceWaitTime, "Traefik TLSStore CRD"); err != nil {
+		log.Printf("WARNING: %v - wildcard certificate issued but not set as Traefik default", err)
+		return nil
+	}
+	if err := client.RefreshDiscovery(ctx); err != nil {
+		log.Printf("Warning: failed to refresh discovery before applying TLSStore: %v", err)
+	}
+
+	if err := applyManifests(ctx, client, "wildcard-tlsstore", buildTLSStoreManifest()); err != nil {
+		return fmt.Errorf("failed to apply default TLSStore: %w", err)
+	}
 	return nil
 }
 
@@ -264,14 +290,13 @@ spec:
 `
 
 // buildWildcardCertManifest renders a cert-manager Certificate for
-// "*.{domain}" plus a Traefik TLSStore making it the default certificate.
+// "*.{domain}" in the traefik namespace.
 func buildWildcardCertManifest(domain, issuerName string) ([]byte, error) {
 	data := wildcardCertData{
 		Name:       "wildcard-" + strings.ReplaceAll(domain, ".", "-"),
 		Domain:     domain,
 		IssuerName: issuerName,
-		SecretName: "wildcard-tls",
-		Namespace:  "traefik",
+		SecretName: wildcardTLSSecretName,
 	}
 
 	tmpl, err := template.New("wildcardcert").Parse(wildcardCertTemplate)
@@ -287,21 +312,38 @@ func buildWildcardCertManifest(domain, issuerName string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// buildTLSStoreManifest renders the Traefik default TLSStore pointing at the
+// wildcard certificate secret.
+func buildTLSStoreManifest() []byte {
+	return []byte(`apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: default
+  namespace: traefik
+spec:
+  defaultCertificate:
+    secretName: ` + wildcardTLSSecretName + `
+`)
+}
+
+// wildcardTLSSecretName is where cert-manager stores the wildcard certificate
+// and where the default TLSStore looks for it.
+const wildcardTLSSecretName = "wildcard-tls"
+
 // wildcardCertData holds the data for rendering the wildcard certificate template.
 type wildcardCertData struct {
 	Name       string
 	Domain     string
 	IssuerName string
 	SecretName string
-	Namespace  string
 }
 
-// wildcardCertTemplate renders the Certificate and the Traefik default TLSStore.
+// wildcardCertTemplate renders the wildcard Certificate.
 const wildcardCertTemplate = `apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ .Name }}
-  namespace: {{ .Namespace }}
+  namespace: traefik
 spec:
   secretName: {{ .SecretName }}
   dnsNames:
@@ -310,13 +352,4 @@ spec:
   issuerRef:
     name: {{ .IssuerName }}
     kind: ClusterIssuer
----
-apiVersion: traefik.io/v1alpha1
-kind: TLSStore
-metadata:
-  name: default
-  namespace: {{ .Namespace }}
-spec:
-  defaultCertificate:
-    secretName: {{ .SecretName }}
 `

--- a/internal/addons/cert_manager_cloudflare.go
+++ b/internal/addons/cert_manager_cloudflare.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"text/template"
 	"time"
 
@@ -55,6 +56,30 @@ func applyCertManagerCloudflare(ctx context.Context, client k8sclient.Client, cf
 		}
 	} else {
 		log.Println("Skipping production ClusterIssuer (no email provided - staging certificates only)")
+	}
+
+	// Wildcard certificate: one DNS01 cert for the whole domain, set as
+	// Traefik's default so ingresses without an explicit TLS secret are
+	// covered. Existing ingresses that name their own secret are unaffected.
+	if cfCfg.WildcardCertificate && cfg.Addons.Cloudflare.Domain != "" {
+		issuerName := "letsencrypt-cloudflare-staging"
+		if cfCfg.Email != "" {
+			issuerName = "letsencrypt-cloudflare-production"
+		}
+
+		manifest, err := buildWildcardCertManifest(cfg.Addons.Cloudflare.Domain, issuerName)
+		if err != nil {
+			return fmt.Errorf("failed to build wildcard certificate manifest: %w", err)
+		}
+
+		// cert-manager installs before traefik, so the namespace may not exist yet.
+		if err := ensureNamespace(ctx, client, "traefik", baselinePodSecurityLabels); err != nil {
+			return err
+		}
+		if err := applyManifests(ctx, client, "wildcard-certificate", manifest); err != nil {
+			return fmt.Errorf("failed to apply wildcard certificate: %w", err)
+		}
+		log.Printf("Wildcard certificate for *.%s requested via %s", cfg.Addons.Cloudflare.Domain, issuerName)
 	}
 
 	return nil
@@ -236,4 +261,62 @@ spec:
           apiTokenSecretRef:
             name: {{ .SecretName }}
             key: {{ .SecretKey }}
+`
+
+// buildWildcardCertManifest renders a cert-manager Certificate for
+// "*.{domain}" plus a Traefik TLSStore making it the default certificate.
+func buildWildcardCertManifest(domain, issuerName string) ([]byte, error) {
+	data := wildcardCertData{
+		Name:       "wildcard-" + strings.ReplaceAll(domain, ".", "-"),
+		Domain:     domain,
+		IssuerName: issuerName,
+		SecretName: "wildcard-tls",
+		Namespace:  "traefik",
+	}
+
+	tmpl, err := template.New("wildcardcert").Parse(wildcardCertTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse wildcard certificate template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to execute wildcard certificate template: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// wildcardCertData holds the data for rendering the wildcard certificate template.
+type wildcardCertData struct {
+	Name       string
+	Domain     string
+	IssuerName string
+	SecretName string
+	Namespace  string
+}
+
+// wildcardCertTemplate renders the Certificate and the Traefik default TLSStore.
+const wildcardCertTemplate = `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  secretName: {{ .SecretName }}
+  dnsNames:
+    - "*.{{ .Domain }}"
+    - "{{ .Domain }}"
+  issuerRef:
+    name: {{ .IssuerName }}
+    kind: ClusterIssuer
+---
+apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: default
+  namespace: {{ .Namespace }}
+spec:
+  defaultCertificate:
+    secretName: {{ .SecretName }}
 `

--- a/internal/addons/cert_manager_cloudflare_test.go
+++ b/internal/addons/cert_manager_cloudflare_test.go
@@ -1,6 +1,7 @@
 package addons
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -162,4 +163,56 @@ func TestClusterIssuerData_Fields(t *testing.T) {
 	assert.Equal(t, "test-secret", data.SecretName)
 	assert.Equal(t, "api-token", data.SecretKey)
 	assert.True(t, data.Production)
+}
+
+func TestBuildWildcardCertManifest(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := buildWildcardCertManifest("example.com", "letsencrypt-cloudflare-production")
+	require.NoError(t, err)
+
+	docs := strings.Split(string(manifest), "\n---\n")
+	require.Len(t, docs, 2, "expected Certificate and TLSStore documents")
+
+	var cert map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(docs[0]), &cert))
+	assert.Equal(t, "cert-manager.io/v1", cert["apiVersion"])
+	assert.Equal(t, "Certificate", cert["kind"])
+
+	certMeta := cert["metadata"].(map[string]any)
+	assert.Equal(t, "wildcard-example-com", certMeta["name"])
+	assert.Equal(t, "traefik", certMeta["namespace"])
+
+	certSpec := cert["spec"].(map[string]any)
+	assert.Equal(t, "wildcard-tls", certSpec["secretName"])
+	assert.ElementsMatch(t, []any{"*.example.com", "example.com"}, certSpec["dnsNames"])
+	issuerRef := certSpec["issuerRef"].(map[string]any)
+	assert.Equal(t, "letsencrypt-cloudflare-production", issuerRef["name"])
+	assert.Equal(t, "ClusterIssuer", issuerRef["kind"])
+
+	var store map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(docs[1]), &store))
+	assert.Equal(t, "traefik.io/v1alpha1", store["apiVersion"])
+	assert.Equal(t, "TLSStore", store["kind"])
+
+	storeMeta := store["metadata"].(map[string]any)
+	assert.Equal(t, "default", storeMeta["name"])
+	assert.Equal(t, "traefik", storeMeta["namespace"])
+
+	storeSpec := store["spec"].(map[string]any)
+	defaultCert := storeSpec["defaultCertificate"].(map[string]any)
+	assert.Equal(t, "wildcard-tls", defaultCert["secretName"])
+}
+
+func TestBuildWildcardCertManifest_SanitizesDomain(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := buildWildcardCertManifest("apps.my-domain.co.uk", "letsencrypt-cloudflare-staging")
+	require.NoError(t, err)
+
+	var cert map[string]any
+	docs := strings.Split(string(manifest), "\n---\n")
+	require.NoError(t, yaml.Unmarshal([]byte(docs[0]), &cert))
+	certMeta := cert["metadata"].(map[string]any)
+	assert.Equal(t, "wildcard-apps-my-domain-co-uk", certMeta["name"])
 }

--- a/internal/addons/cert_manager_cloudflare_test.go
+++ b/internal/addons/cert_manager_cloudflare_test.go
@@ -1,12 +1,13 @@
 package addons
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/milankappen/k8zner/internal/config"
 )
 
 func TestBuildClusterIssuerManifest_Staging(t *testing.T) {
@@ -171,11 +172,8 @@ func TestBuildWildcardCertManifest(t *testing.T) {
 	manifest, err := buildWildcardCertManifest("example.com", "letsencrypt-cloudflare-production")
 	require.NoError(t, err)
 
-	docs := strings.Split(string(manifest), "\n---\n")
-	require.Len(t, docs, 2, "expected Certificate and TLSStore documents")
-
 	var cert map[string]any
-	require.NoError(t, yaml.Unmarshal([]byte(docs[0]), &cert))
+	require.NoError(t, yaml.Unmarshal(manifest, &cert))
 	assert.Equal(t, "cert-manager.io/v1", cert["apiVersion"])
 	assert.Equal(t, "Certificate", cert["kind"])
 
@@ -189,9 +187,13 @@ func TestBuildWildcardCertManifest(t *testing.T) {
 	issuerRef := certSpec["issuerRef"].(map[string]any)
 	assert.Equal(t, "letsencrypt-cloudflare-production", issuerRef["name"])
 	assert.Equal(t, "ClusterIssuer", issuerRef["kind"])
+}
+
+func TestBuildTLSStoreManifest(t *testing.T) {
+	t.Parallel()
 
 	var store map[string]any
-	require.NoError(t, yaml.Unmarshal([]byte(docs[1]), &store))
+	require.NoError(t, yaml.Unmarshal(buildTLSStoreManifest(), &store))
 	assert.Equal(t, "traefik.io/v1alpha1", store["apiVersion"])
 	assert.Equal(t, "TLSStore", store["kind"])
 
@@ -204,6 +206,16 @@ func TestBuildWildcardCertManifest(t *testing.T) {
 	assert.Equal(t, "wildcard-tls", defaultCert["secretName"])
 }
 
+func TestCloudflareIssuerName(t *testing.T) {
+	t.Parallel()
+
+	withEmail := config.CertManagerCloudflareConfig{Email: "ops@example.com"}
+	assert.Equal(t, "letsencrypt-cloudflare-production", cloudflareIssuerName(withEmail))
+
+	// Without an email only the staging issuer exists.
+	assert.Equal(t, "letsencrypt-cloudflare-staging", cloudflareIssuerName(config.CertManagerCloudflareConfig{}))
+}
+
 func TestBuildWildcardCertManifest_SanitizesDomain(t *testing.T) {
 	t.Parallel()
 
@@ -211,8 +223,7 @@ func TestBuildWildcardCertManifest_SanitizesDomain(t *testing.T) {
 	require.NoError(t, err)
 
 	var cert map[string]any
-	docs := strings.Split(string(manifest), "\n---\n")
-	require.NoError(t, yaml.Unmarshal([]byte(docs[0]), &cert))
+	require.NoError(t, yaml.Unmarshal(manifest, &cert))
 	certMeta := cert["metadata"].(map[string]any)
 	assert.Equal(t, "wildcard-apps-my-domain-co-uk", certMeta["name"])
 }

--- a/internal/addons/cert_manager_test.go
+++ b/internal/addons/cert_manager_test.go
@@ -209,9 +209,12 @@ func TestBuildCertManagerValues_GatewayAPI(t *testing.T) {
 
 func TestCertManagerNamespace(t *testing.T) {
 	t.Parallel()
-	ns := helm.NamespaceManifest("cert-manager", nil)
+	ns := helm.NamespaceManifest("cert-manager", withBaselinePodSecurity(nil))
 
 	assert.Contains(t, ns, "apiVersion: v1")
 	assert.Contains(t, ns, "kind: Namespace")
 	assert.Contains(t, ns, "name: cert-manager")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/enforce: baseline")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/audit: baseline")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/warn: baseline")
 }

--- a/internal/addons/cloudflare_secret.go
+++ b/internal/addons/cloudflare_secret.go
@@ -23,7 +23,7 @@ func createCloudflareSecrets(ctx context.Context, client k8sclient.Client, cfg *
 
 	// Create namespaces first if needed
 	if cfg.Addons.ExternalDNS.Enabled {
-		if err := ensureNamespace(ctx, client, "external-dns", nil); err != nil {
+		if err := ensureNamespace(ctx, client, "external-dns", withBaselinePodSecurity(nil)); err != nil {
 			return err
 		}
 

--- a/internal/addons/cloudflare_secret_test.go
+++ b/internal/addons/cloudflare_secret_test.go
@@ -82,11 +82,14 @@ func TestCreateCloudflareSecret(t *testing.T) {
 
 func TestExternalDNSNamespace(t *testing.T) {
 	t.Parallel()
-	namespaceYAML := helm.NamespaceManifest("external-dns", nil)
+	namespaceYAML := helm.NamespaceManifest("external-dns", withBaselinePodSecurity(nil))
 
 	assert.Contains(t, namespaceYAML, "apiVersion: v1")
 	assert.Contains(t, namespaceYAML, "kind: Namespace")
 	assert.Contains(t, namespaceYAML, "name: external-dns")
+	assert.Contains(t, namespaceYAML, "pod-security.kubernetes.io/enforce: baseline")
+	assert.Contains(t, namespaceYAML, "pod-security.kubernetes.io/audit: baseline")
+	assert.Contains(t, namespaceYAML, "pod-security.kubernetes.io/warn: baseline")
 }
 
 func TestCreateCloudflareSecret_SecretNameConstant(t *testing.T) {

--- a/internal/addons/helm/registry.go
+++ b/internal/addons/helm/registry.go
@@ -49,4 +49,14 @@ var DefaultChartSpecs = map[string]ChartSpec{
 		Name:       "kube-prometheus-stack",
 		Version:    "72.6.2",
 	},
+	"loki": {
+		Repository: "https://grafana.github.io/helm-charts",
+		Name:       "loki",
+		Version:    "6.55.0",
+	},
+	"alloy": {
+		Repository: "https://grafana.github.io/helm-charts",
+		Name:       "alloy",
+		Version:    "1.9.0",
+	},
 }

--- a/internal/addons/kube_prometheus_stack.go
+++ b/internal/addons/kube_prometheus_stack.go
@@ -12,7 +12,7 @@ import (
 
 // applyKubePrometheusStack installs the kube-prometheus-stack (Prometheus, Grafana, Alertmanager).
 func applyKubePrometheusStack(ctx context.Context, client k8sclient.Client, cfg *config.Config) error {
-	if err := ensureNamespace(ctx, client, "monitoring", withBaselinePodSecurity(map[string]string{"name": "monitoring"})); err != nil {
+	if err := ensureNamespace(ctx, client, "monitoring", withHostAccessPodSecurity(map[string]string{"name": "monitoring"})); err != nil {
 		return err
 	}
 

--- a/internal/addons/kube_prometheus_stack.go
+++ b/internal/addons/kube_prometheus_stack.go
@@ -12,7 +12,7 @@ import (
 
 // applyKubePrometheusStack installs the kube-prometheus-stack (Prometheus, Grafana, Alertmanager).
 func applyKubePrometheusStack(ctx context.Context, client k8sclient.Client, cfg *config.Config) error {
-	if err := ensureNamespace(ctx, client, "monitoring", map[string]string{"name": "monitoring"}); err != nil {
+	if err := ensureNamespace(ctx, client, "monitoring", withBaselinePodSecurity(map[string]string{"name": "monitoring"})); err != nil {
 		return err
 	}
 

--- a/internal/addons/kube_prometheus_stack_test.go
+++ b/internal/addons/kube_prometheus_stack_test.go
@@ -348,11 +348,14 @@ func TestBuildResourceValues(t *testing.T) {
 
 func TestMonitoringNamespace(t *testing.T) {
 	t.Parallel()
-	ns := helm.NamespaceManifest("monitoring", map[string]string{"name": "monitoring"})
+	ns := helm.NamespaceManifest("monitoring", withBaselinePodSecurity(map[string]string{"name": "monitoring"}))
 
 	assert.Contains(t, ns, "apiVersion: v1")
 	assert.Contains(t, ns, "kind: Namespace")
 	assert.Contains(t, ns, "name: monitoring")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/enforce: baseline")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/audit: baseline")
+	assert.Contains(t, ns, "pod-security.kubernetes.io/warn: baseline")
 }
 
 func TestBuildGrafanaValues_AdminPassword(t *testing.T) {

--- a/internal/addons/kube_prometheus_stack_test.go
+++ b/internal/addons/kube_prometheus_stack_test.go
@@ -348,12 +348,14 @@ func TestBuildResourceValues(t *testing.T) {
 
 func TestMonitoringNamespace(t *testing.T) {
 	t.Parallel()
-	ns := helm.NamespaceManifest("monitoring", withBaselinePodSecurity(map[string]string{"name": "monitoring"}))
+	ns := helm.NamespaceManifest("monitoring", withHostAccessPodSecurity(map[string]string{"name": "monitoring"}))
 
 	assert.Contains(t, ns, "apiVersion: v1")
 	assert.Contains(t, ns, "kind: Namespace")
 	assert.Contains(t, ns, "name: monitoring")
-	assert.Contains(t, ns, "pod-security.kubernetes.io/enforce: baseline")
+	// node-exporter needs hostPath/hostNetwork/hostPID, which baseline
+	// forbids: enforcing baseline here would reject its pods.
+	assert.Contains(t, ns, "pod-security.kubernetes.io/enforce: privileged")
 	assert.Contains(t, ns, "pod-security.kubernetes.io/audit: baseline")
 	assert.Contains(t, ns, "pod-security.kubernetes.io/warn: baseline")
 }

--- a/internal/addons/kubectl.go
+++ b/internal/addons/kubectl.go
@@ -19,6 +19,20 @@ var baselinePodSecurityLabels = map[string]string{
 	"pod-security.kubernetes.io/warn":    "baseline",
 }
 
+// withBaselinePodSecurity merges the baseline pod security labels into the given
+// label map. Caller-provided keys win on conflict, and the input map is left
+// untouched so shared label maps stay safe to reuse.
+func withBaselinePodSecurity(labels map[string]string) map[string]string {
+	merged := make(map[string]string, len(labels)+len(baselinePodSecurityLabels))
+	for k, v := range baselinePodSecurityLabels {
+		merged[k] = v
+	}
+	for k, v := range labels {
+		merged[k] = v
+	}
+	return merged
+}
+
 // ensureNamespace creates a Kubernetes namespace with the given labels using server-side apply.
 func ensureNamespace(ctx context.Context, client k8sclient.Client, name string, labels map[string]string) error {
 	yaml := helm.NamespaceManifest(name, labels)

--- a/internal/addons/kubectl.go
+++ b/internal/addons/kubectl.go
@@ -33,6 +33,16 @@ func withBaselinePodSecurity(labels map[string]string) map[string]string {
 	return merged
 }
 
+// withHostAccessPodSecurity merges pod security labels for namespaces whose
+// workloads legitimately need host access (hostPath/hostNetwork/hostPID, e.g.
+// node-exporter): enforcement stays open while audit/warn record baseline
+// violations for visibility.
+func withHostAccessPodSecurity(labels map[string]string) map[string]string {
+	merged := withBaselinePodSecurity(labels)
+	merged["pod-security.kubernetes.io/enforce"] = "privileged"
+	return merged
+}
+
 // ensureNamespace creates a Kubernetes namespace with the given labels using server-side apply.
 func ensureNamespace(ctx context.Context, client k8sclient.Client, name string, labels map[string]string) error {
 	yaml := helm.NamespaceManifest(name, labels)

--- a/internal/addons/kubectl_test.go
+++ b/internal/addons/kubectl_test.go
@@ -59,6 +59,61 @@ func (m *mockK8sClient) HasIngressClass(ctx context.Context, name string) (bool,
 	return args.Bool(0), args.Error(1)
 }
 
+func TestWithBaselinePodSecurity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]string
+	}{
+		{
+			name:   "nil map gets baseline labels",
+			labels: nil,
+			want: map[string]string{
+				"pod-security.kubernetes.io/enforce": "baseline",
+				"pod-security.kubernetes.io/audit":   "baseline",
+				"pod-security.kubernetes.io/warn":    "baseline",
+			},
+		},
+		{
+			name:   "existing labels preserved",
+			labels: map[string]string{"name": "argocd"},
+			want: map[string]string{
+				"name":                               "argocd",
+				"pod-security.kubernetes.io/enforce": "baseline",
+				"pod-security.kubernetes.io/audit":   "baseline",
+				"pod-security.kubernetes.io/warn":    "baseline",
+			},
+		},
+		{
+			name:   "caller-provided keys are not overwritten",
+			labels: map[string]string{"pod-security.kubernetes.io/enforce": "privileged"},
+			want: map[string]string{
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"pod-security.kubernetes.io/audit":   "baseline",
+				"pod-security.kubernetes.io/warn":    "baseline",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := withBaselinePodSecurity(tt.labels)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWithBaselinePodSecurity_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	input := map[string]string{"name": "monitoring"}
+
+	_ = withBaselinePodSecurity(input)
+
+	assert.Equal(t, map[string]string{"name": "monitoring"}, input)
+}
+
 func TestApplyManifests(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/addons/kubectl_test.go
+++ b/internal/addons/kubectl_test.go
@@ -306,3 +306,14 @@ func TestApplyFromURL_ContextCanceled(t *testing.T) {
 	err := applyFromURL(ctx, client, "test-addon", server.URL)
 	require.Error(t, err)
 }
+
+func TestWithHostAccessPodSecurity(t *testing.T) {
+	t.Parallel()
+
+	labels := withHostAccessPodSecurity(map[string]string{"name": "monitoring"})
+
+	assert.Equal(t, "privileged", labels["pod-security.kubernetes.io/enforce"])
+	assert.Equal(t, "baseline", labels["pod-security.kubernetes.io/audit"])
+	assert.Equal(t, "baseline", labels["pod-security.kubernetes.io/warn"])
+	assert.Equal(t, "monitoring", labels["name"])
+}

--- a/internal/addons/logging.go
+++ b/internal/addons/logging.go
@@ -10,10 +10,6 @@ import (
 	"github.com/milankappen/k8zner/internal/config"
 )
 
-// defaultLogRetention bounds how long Loki keeps logs when the user does not
-// configure a retention period.
-const defaultLogRetention = "168h"
-
 // lokiEndpoint is the in-cluster push/query URL for the Loki single binary.
 const lokiEndpoint = "http://loki.logging.svc.cluster.local:3100"
 
@@ -58,7 +54,7 @@ func logRetention(cfg *config.Config) string {
 	if r := cfg.Addons.Logging.Retention; r != "" {
 		return r
 	}
-	return defaultLogRetention
+	return config.LoggingDefaultRetention
 }
 
 // buildLokiValues renders helm values for a single-binary Loki suited to the

--- a/internal/addons/logging.go
+++ b/internal/addons/logging.go
@@ -1,0 +1,172 @@
+package addons
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/milankappen/k8zner/internal/addons/helm"
+	"github.com/milankappen/k8zner/internal/addons/k8sclient"
+	"github.com/milankappen/k8zner/internal/config"
+)
+
+// defaultLogRetention bounds how long Loki keeps logs when the user does not
+// configure a retention period.
+const defaultLogRetention = "168h"
+
+// lokiEndpoint is the in-cluster push/query URL for the Loki single binary.
+const lokiEndpoint = "http://loki.logging.svc.cluster.local:3100"
+
+// applyLogging installs the logging stack: Loki (single binary, persisted via
+// the Hetzner CSI default storage class) and Grafana Alloy as the collector.
+// Alloy tails pod logs through the Kubernetes API rather than hostPath
+// mounts, so the namespace stays on baseline pod security.
+func applyLogging(ctx context.Context, client k8sclient.Client, cfg *config.Config) error {
+	if !cfg.Addons.Logging.Enabled {
+		return nil
+	}
+
+	if err := ensureNamespace(ctx, client, "logging", withBaselinePodSecurity(map[string]string{"name": "logging"})); err != nil {
+		return err
+	}
+
+	log.Printf("[addons] Installing Loki (retention=%s)...", logRetention(cfg))
+	if err := installHelmAddon(ctx, client, "loki", "logging", cfg.Addons.Logging.LokiHelm, buildLokiValues(cfg)); err != nil {
+		return fmt.Errorf("failed to install Loki: %w", err)
+	}
+
+	log.Printf("[addons] Installing Alloy log collector...")
+	if err := installHelmAddon(ctx, client, "alloy", "logging", cfg.Addons.Logging.AlloyHelm, buildAlloyValues()); err != nil {
+		return fmt.Errorf("failed to install Alloy: %w", err)
+	}
+
+	// Register Loki as a Grafana datasource when monitoring is installed:
+	// the kube-prometheus-stack Grafana sidecar watches for this label.
+	if cfg.Addons.KubePrometheusStack.Enabled {
+		log.Printf("[addons] Registering Loki datasource in Grafana...")
+		if err := applyManifests(ctx, client, "loki-datasource", buildLokiDatasourceManifest()); err != nil {
+			return fmt.Errorf("failed to apply Loki datasource: %w", err)
+		}
+	}
+
+	log.Printf("[addons] Logging stack installed successfully")
+	return nil
+}
+
+// logRetention returns the configured retention with the default applied.
+func logRetention(cfg *config.Config) string {
+	if r := cfg.Addons.Logging.Retention; r != "" {
+		return r
+	}
+	return defaultLogRetention
+}
+
+// buildLokiValues renders helm values for a single-binary Loki suited to the
+// cluster sizes k8zner targets: filesystem storage on a persistent volume,
+// no caches, no canary, no gateway.
+func buildLokiValues(cfg *config.Config) helm.Values {
+	return helm.Values{
+		"deploymentMode": "SingleBinary",
+		"loki": helm.Values{
+			"auth_enabled": false,
+			"commonConfig": helm.Values{
+				"replication_factor": 1,
+			},
+			"storage": helm.Values{
+				"type": "filesystem",
+			},
+			"schemaConfig": helm.Values{
+				"configs": []helm.Values{
+					{
+						"from":         "2024-01-01",
+						"store":        "tsdb",
+						"object_store": "filesystem",
+						"schema":       "v13",
+						"index": helm.Values{
+							"prefix": "index_",
+							"period": "24h",
+						},
+					},
+				},
+			},
+			"limits_config": helm.Values{
+				"retention_period": logRetention(cfg),
+			},
+			"compactor": helm.Values{
+				"retention_enabled":    true,
+				"delete_request_store": "filesystem",
+			},
+		},
+		"singleBinary": helm.Values{
+			"replicas": 1,
+			"persistence": helm.Values{
+				"enabled": true,
+				"size":    "10Gi",
+			},
+		},
+		"backend":      helm.Values{"replicas": 0},
+		"read":         helm.Values{"replicas": 0},
+		"write":        helm.Values{"replicas": 0},
+		"chunksCache":  helm.Values{"enabled": false},
+		"resultsCache": helm.Values{"enabled": false},
+		"lokiCanary":   helm.Values{"enabled": false},
+		"gateway":      helm.Values{"enabled": false},
+		"test":         helm.Values{"enabled": false},
+	}
+}
+
+// buildAlloyValues renders helm values for Grafana Alloy configured to tail
+// all pod logs via the Kubernetes API and push them to Loki. API-based
+// tailing needs no hostPath mounts, so a single replica suffices and the pod
+// passes baseline pod security.
+func buildAlloyValues() helm.Values {
+	alloyConfig := `discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+loki.source.kubernetes "pods" {
+  targets    = discovery.kubernetes.pods.targets
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "` + lokiEndpoint + `/loki/api/v1/push"
+  }
+}
+`
+
+	return helm.Values{
+		"alloy": helm.Values{
+			"configMap": helm.Values{
+				"content": alloyConfig,
+			},
+		},
+		"controller": helm.Values{
+			"type":     "statefulset",
+			"replicas": 1,
+		},
+	}
+}
+
+// buildLokiDatasourceManifest renders the ConfigMap the kube-prometheus-stack
+// Grafana sidecar picks up to register Loki as a datasource.
+func buildLokiDatasourceManifest() []byte {
+	return []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-datasource
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+data:
+  loki-datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: ` + lokiEndpoint + `
+        isDefault: false
+`)
+}

--- a/internal/addons/logging_test.go
+++ b/internal/addons/logging_test.go
@@ -56,7 +56,7 @@ func TestBuildLokiValues_RetentionDefault(t *testing.T) {
 
 	values := buildLokiValues(cfg)
 	limits := values["loki"].(helm.Values)["limits_config"].(helm.Values)
-	assert.Equal(t, defaultLogRetention, limits["retention_period"])
+	assert.Equal(t, config.LoggingDefaultRetention, limits["retention_period"])
 }
 
 func TestBuildAlloyValues(t *testing.T) {

--- a/internal/addons/logging_test.go
+++ b/internal/addons/logging_test.go
@@ -1,0 +1,106 @@
+package addons
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milankappen/k8zner/internal/addons/helm"
+	"github.com/milankappen/k8zner/internal/config"
+)
+
+func loggingTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Addons.Logging.Enabled = true
+	cfg.Addons.Logging.Retention = "168h"
+	return cfg
+}
+
+func TestBuildLokiValues(t *testing.T) {
+	t.Parallel()
+
+	values := buildLokiValues(loggingTestConfig())
+
+	assert.Equal(t, "SingleBinary", values["deploymentMode"])
+
+	loki := values["loki"].(helm.Values)
+	assert.Equal(t, false, loki["auth_enabled"])
+
+	limits := loki["limits_config"].(helm.Values)
+	assert.Equal(t, "168h", limits["retention_period"])
+
+	single := values["singleBinary"].(helm.Values)
+	assert.Equal(t, 1, single["replicas"])
+	persistence := single["persistence"].(helm.Values)
+	assert.Equal(t, true, persistence["enabled"])
+
+	// The simple scalable targets must be off in single binary mode.
+	for _, target := range []string{"backend", "read", "write"} {
+		section := values[target].(helm.Values)
+		assert.Equal(t, 0, section["replicas"], "%s replicas", target)
+	}
+
+	// No caches or canaries on small clusters.
+	assert.Equal(t, false, values["chunksCache"].(helm.Values)["enabled"])
+	assert.Equal(t, false, values["resultsCache"].(helm.Values)["enabled"])
+	assert.Equal(t, false, values["lokiCanary"].(helm.Values)["enabled"])
+}
+
+func TestBuildLokiValues_RetentionDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := loggingTestConfig()
+	cfg.Addons.Logging.Retention = ""
+
+	values := buildLokiValues(cfg)
+	limits := values["loki"].(helm.Values)["limits_config"].(helm.Values)
+	assert.Equal(t, defaultLogRetention, limits["retention_period"])
+}
+
+func TestBuildAlloyValues(t *testing.T) {
+	t.Parallel()
+
+	values := buildAlloyValues()
+
+	alloy := values["alloy"].(helm.Values)
+	configMap := alloy["configMap"].(helm.Values)
+	content := configMap["content"].(string)
+
+	// Logs are tailed via the Kubernetes API (no hostPath mounts), so the
+	// collector stays compatible with baseline pod security.
+	assert.Contains(t, content, "loki.source.kubernetes")
+	assert.Contains(t, content, "http://loki.logging.svc.cluster.local:3100/loki/api/v1/push")
+	assert.NotContains(t, content, "/var/log")
+
+	controller := values["controller"].(helm.Values)
+	assert.Equal(t, "statefulset", controller["type"])
+	assert.Equal(t, 1, controller["replicas"])
+}
+
+func TestBuildLokiDatasourceManifest(t *testing.T) {
+	t.Parallel()
+
+	manifest := buildLokiDatasourceManifest()
+	rendered := string(manifest)
+
+	// The grafana sidecar from kube-prometheus-stack discovers datasources
+	// by this label.
+	assert.Contains(t, rendered, "grafana_datasource")
+	assert.Contains(t, rendered, "namespace: monitoring")
+	assert.Contains(t, rendered, "http://loki.logging.svc.cluster.local:3100")
+	require.True(t, strings.Contains(rendered, "type: loki"))
+}
+
+func TestEnabledSteps_IncludesLogging(t *testing.T) {
+	t.Parallel()
+
+	cfg := loggingTestConfig()
+	steps := EnabledSteps(cfg)
+
+	require.Len(t, steps, 1)
+	assert.Equal(t, StepLogging, steps[0].Name)
+	assert.Equal(t, 11, steps[0].Order)
+	assert.Equal(t, helm.DefaultChartSpecs["loki"].Version, steps[0].Version)
+}

--- a/internal/addons/logging_test.go
+++ b/internal/addons/logging_test.go
@@ -102,5 +102,19 @@ func TestEnabledSteps_IncludesLogging(t *testing.T) {
 	require.Len(t, steps, 1)
 	assert.Equal(t, StepLogging, steps[0].Name)
 	assert.Equal(t, 11, steps[0].Order)
-	assert.Equal(t, helm.DefaultChartSpecs["loki"].Version, steps[0].Version)
+	// Composite version: bumping either chart must register as an upgrade.
+	assert.Contains(t, steps[0].Version, helm.DefaultChartSpecs["loki"].Version)
+	assert.Contains(t, steps[0].Version, helm.DefaultChartSpecs["alloy"].Version)
+}
+
+func TestEnabledSteps_LoggingVersionTracksAlloy(t *testing.T) {
+	t.Parallel()
+
+	base := EnabledSteps(loggingTestConfig())[0].Version
+
+	cfg := loggingTestConfig()
+	cfg.Addons.Logging.AlloyHelm.Version = "9.9.9"
+	bumped := EnabledSteps(cfg)[0].Version
+
+	assert.NotEqual(t, base, bumped, "an alloy chart bump must trigger a logging upgrade")
 }

--- a/internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml
+++ b/internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml
@@ -94,6 +94,12 @@ spec:
                     default: true
                     description: Traefik ingress controller
                     type: boolean
+                  wildcardCertificate:
+                    description: |-
+                      WildcardCertificate additionally issues a "*.{domain}" certificate via
+                      DNS01 and sets it as Traefik's default certificate, so ingresses
+                      without an explicit TLS secret are covered. Requires domain.
+                    type: boolean
                 type: object
               backup:
                 description: Backup configures automated etcd backups

--- a/internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml
+++ b/internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml
@@ -62,6 +62,8 @@ spec:
                     description: |-
                       ArgoSubdomain overrides the default "argo" subdomain for ArgoCD ingress.
                       The full host will be "{argoSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
                   argocd:
                     description: ArgoCD for GitOps
@@ -77,6 +79,8 @@ spec:
                     description: |-
                       GrafanaSubdomain overrides the default "grafana" subdomain for Grafana ingress.
                       The full host will be "{grafanaSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
                   metricsServer:
                     default: true
@@ -163,7 +167,7 @@ spec:
                   size:
                     default: cx23
                     description: |-
-                      Size is the Hetzner server type (e.g., cx23, cx33, cpx21, cpx31)
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
                       CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
                     type: string
                 required:
@@ -171,8 +175,10 @@ spec:
                 - size
                 type: object
               credentialsRef:
-                description: CredentialsRef references the Secret containing HCloud
-                  token and Talos secrets
+                description: |-
+                  CredentialsRef references the Secret containing HCloud token and Talos secrets.
+                  Once set, it cannot be changed or removed: swapping credentials mid-lifecycle
+                  would silently re-point provisioning at a different Hetzner project.
                 properties:
                   name:
                     default: ""
@@ -185,10 +191,16 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: credentialsRef is immutable once set
+                  rule: '!has(oldSelf.name) || oldSelf.name == "" || (has(self.name)
+                    && self.name == oldSelf.name)'
               domain:
                 description: |-
                   Domain is the base domain for ingress resources (e.g., "example.com").
                   When set, addons like ArgoCD and Grafana will have ingress automatically configured.
+                maxLength: 253
+                pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$
                 type: string
               firewall:
                 description: Firewall configures the cluster firewall rules
@@ -271,6 +283,9 @@ spec:
                 - nbg1
                 - hel1
                 type: string
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: self == oldSelf
               talos:
                 description: Talos specifies the Talos configuration
                 properties:
@@ -302,7 +317,7 @@ spec:
                   size:
                     default: cx23
                     description: |-
-                      Size is the Hetzner server type (e.g., cx23, cx33, cpx21, cpx31)
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
                       CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
                     type: string
                 required:
@@ -496,8 +511,8 @@ spec:
                       description: NodeStatus represents the status of a single node.
                       properties:
                         healthy:
-                          description: Healthy indicates if the node is healthy (deprecated,
-                            use Phase)
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
                           type: boolean
                         lastHealthCheck:
                           description: LastHealthCheck is when health was last checked
@@ -724,8 +739,8 @@ spec:
                       description: NodeStatus represents the status of a single node.
                       properties:
                         healthy:
-                          description: Healthy indicates if the node is healthy (deprecated,
-                            use Phase)
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
                           type: boolean
                         lastHealthCheck:
                           description: LastHealthCheck is when health was last checked

--- a/internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml
+++ b/internal/addons/operator-chart/crds/k8zner.io_k8znerclusters.yaml
@@ -82,6 +82,10 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
+                  logging:
+                    description: Logging enables the Loki + Alloy log aggregation
+                      stack
+                    type: boolean
                   metricsServer:
                     default: true
                     description: MetricsServer for resource metrics

--- a/internal/addons/operator-chart/templates/deployment.yaml
+++ b/internal/addons/operator-chart/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "k8zner-operator.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -44,6 +47,7 @@ spec:
           args:
             - --metrics-bind-address=:{{ .Values.metrics.port }}
             - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+            - --log-level={{ .Values.logLevel }}
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect=true
             - --leader-election-id={{ .Values.leaderElection.resourceName }}
@@ -51,15 +55,10 @@ spec:
             - --leader-elect=false
             {{- end }}
           env:
-            - name: HCLOUD_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "k8zner-operator.credentialsSecretName" . }}
-                  key: {{ .Values.credentials.existingSecretKey }}
-            {{- if eq .Values.logLevel "debug" }}
-            - name: DEBUG
-              value: "true"
-            {{- end }}
+            # The token is mounted as a file rather than injected as an env var
+            # so it never shows up in `kubectl describe pod` or env dumps.
+            - name: HCLOUD_TOKEN_FILE
+              value: /var/run/secrets/k8zner/{{ .Values.credentials.existingSecretKey }}
             {{- if .Values.hostNetwork }}
             - name: KUBERNETES_SERVICE_HOST
               value: "localhost"
@@ -88,6 +87,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            - name: credentials
+              mountPath: /var/run/secrets/k8zner
+              readOnly: true
             - name: helm-cache
               mountPath: /home/nonroot/.cache
             - name: helm-config
@@ -95,6 +97,10 @@ spec:
             - name: tmp
               mountPath: /tmp
       volumes:
+        - name: credentials
+          secret:
+            secretName: {{ include "k8zner-operator.credentialsSecretName" . }}
+            defaultMode: 288 # 0440 in decimal; YAML 1.2 parsers read 0440 as decimal 440
         - name: helm-cache
           emptyDir: {}
         - name: helm-config

--- a/internal/addons/operator-chart/templates/networkpolicy.yaml
+++ b/internal/addons/operator-chart/templates/networkpolicy.yaml
@@ -1,0 +1,53 @@
+{{- /*
+NetworkPolicies do not apply to hostNetwork pods, so skip rendering when the
+operator runs in hostNetwork mode (e.g. before CNI is installed).
+*/}}
+{{- if and .Values.networkPolicy.enabled (not .Values.hostNetwork) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "k8zner-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8zner-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "k8zner-operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow metrics scraping and health probes from anywhere in-cluster.
+    # Kubelet probes originate from the node itself, which NetworkPolicy
+    # cannot select reliably, so no `from` restriction is applied; all
+    # other ingress is denied because this policy selects the pod.
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.metrics.port }}
+        - protocol: TCP
+          port: {{ .Values.healthProbe.port }}
+  egress:
+    # DNS resolution (CoreDNS and upstream resolvers).
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # The Hetzner Cloud API, Helm chart repositories, ghcr.io, the Kubernetes
+    # apiserver, and the Talos API on cluster nodes are all outside the
+    # cluster network, so they cannot be selected more precisely than by CIDR:
+    #   - 443:   HTTPS (Hetzner Cloud API, chart repos, ghcr.io, apiserver LB)
+    #   - 6443:  Kubernetes apiserver
+    #   - 50000: Talos API on cluster nodes
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 50000
+{{- end }}

--- a/internal/addons/operator-chart/templates/poddisruptionbudget.yaml
+++ b/internal/addons/operator-chart/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "k8zner-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8zner-operator.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "k8zner-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/internal/addons/operator-chart/templates/rbac.yaml
+++ b/internal/addons/operator-chart/templates/rbac.yaml
@@ -19,6 +19,14 @@ metadata:
   labels:
     {{- include "k8zner-operator.labels" . | nindent 4 }}
 rules:
+  # CRD self-apply at startup (create cannot be scoped by resourceNames)
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["k8znerclusters.k8zner.io"]
+    verbs: ["get", "update", "patch"]
   # K8znerCluster CRD
   - apiGroups: ["k8zner.io"]
     resources: ["k8znerclusters"]

--- a/internal/addons/operator-chart/values.yaml
+++ b/internal/addons/operator-chart/values.yaml
@@ -33,8 +33,22 @@ credentials:
 podAnnotations: {}
 podLabels: {}
 
+# Priority class for the operator pods. The operator self-heals the cluster it
+# runs on, so consider "system-cluster-critical" to protect it from eviction
+# under node pressure. Empty means no priority class.
+priorityClassName: ""
+
+# Keep at least one operator replica available during voluntary disruptions
+# (node drains, upgrades). Only rendered when replicaCount > 1.
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
 podSecurityContext:
   runAsNonRoot: true
+  # Group-own mounted volumes (the credentials secret) so the nonroot user
+  # can read them with a restrictive file mode.
+  fsGroup: 65532
   seccompProfile:
     type: RuntimeDefault
 

--- a/internal/addons/operator-chart/values.yaml
+++ b/internal/addons/operator-chart/values.yaml
@@ -115,5 +115,11 @@ metrics:
 healthProbe:
   port: 8081
 
+# NetworkPolicy restricting the operator pod to the traffic it needs.
+# Not rendered when hostNetwork is enabled, because NetworkPolicies do not
+# apply to hostNetwork pods.
+networkPolicy:
+  enabled: true
+
 # Log level (debug, info, error)
 logLevel: info

--- a/internal/addons/operator_chart_render_test.go
+++ b/internal/addons/operator_chart_render_test.go
@@ -1,0 +1,54 @@
+package addons
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/milankappen/k8zner/internal/addons/helm"
+	"github.com/milankappen/k8zner/internal/config"
+)
+
+// TestOperatorChartRenders renders the embedded operator chart with the same
+// values the CLI uses and asserts the security-relevant invariants of the
+// resulting manifests, so chart edits that weaken them fail fast.
+func TestOperatorChartRenders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{HCloudToken: "test-token"}
+	cfg.Addons.Operator.Enabled = true
+
+	chartPath, cleanup, err := extractOperatorChart()
+	if err != nil {
+		t.Fatalf("failed to extract embedded chart: %v", err)
+	}
+	defer cleanup()
+
+	out, err := helm.RenderFromPath(chartPath, "k8zner-operator", "k8zner-system", buildOperatorValues(cfg))
+	if err != nil {
+		t.Fatalf("failed to render operator chart: %v", err)
+	}
+	rendered := string(out)
+
+	for _, want := range []string{
+		// Token reaches the operator as a mounted file, not an env var.
+		"HCLOUD_TOKEN_FILE",
+		"/var/run/secrets/k8zner/hcloud-token",
+		"defaultMode: 288", // 0440 secret volume
+		"fsGroup: 65532",
+		// Default replicaCount is 2, so the PDB must render.
+		"PodDisruptionBudget",
+		"minAvailable: 1",
+		// Log level wired through as a flag.
+		"--log-level=info",
+		"readOnlyRootFilesystem: true",
+		"runAsNonRoot: true",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered chart missing %q", want)
+		}
+	}
+
+	if strings.Contains(rendered, "name: HCLOUD_TOKEN\n") {
+		t.Error("token must not be injected as the HCLOUD_TOKEN env var")
+	}
+}

--- a/internal/addons/operator_chart_render_test.go
+++ b/internal/addons/operator_chart_render_test.go
@@ -52,3 +52,69 @@ func TestOperatorChartRenders(t *testing.T) {
 		t.Error("token must not be injected as the HCLOUD_TOKEN env var")
 	}
 }
+
+// TestOperatorChartNetworkPolicy asserts the chart ships a default-on
+// NetworkPolicy locking the operator pod down to the ports it needs, and that
+// the policy is skipped in hostNetwork mode where NetworkPolicies don't apply.
+func TestOperatorChartNetworkPolicy(t *testing.T) {
+	t.Parallel()
+
+	chartPath, cleanup, err := extractOperatorChart()
+	if err != nil {
+		t.Fatalf("failed to extract embedded chart: %v", err)
+	}
+	defer cleanup()
+
+	t.Run("rendered by default with expected ports", func(t *testing.T) {
+		cfg := &config.Config{HCloudToken: "test-token"}
+		cfg.Addons.Operator.Enabled = true
+		cfg.Addons.Operator.HostNetwork = false
+
+		out, err := helm.RenderFromPath(chartPath, "k8zner-operator", "k8zner-system", buildOperatorValues(cfg))
+		if err != nil {
+			t.Fatalf("failed to render operator chart: %v", err)
+		}
+		rendered := string(out)
+
+		if !strings.Contains(rendered, "kind: NetworkPolicy") {
+			t.Fatal("rendered chart missing NetworkPolicy")
+		}
+
+		for _, want := range []string{
+			// Both Ingress and Egress are restricted.
+			"- Ingress",
+			"- Egress",
+			// Ingress: metrics and health probe ports only.
+			"port: 8080",
+			"port: 8081",
+			// Egress: DNS over UDP and TCP.
+			"port: 53",
+			"protocol: UDP",
+			// Egress: HTTPS (Hetzner API, chart repos, ghcr, apiserver via LB).
+			"port: 443",
+			// Egress: Kubernetes apiserver.
+			"port: 6443",
+			// Egress: Talos API on cluster nodes.
+			"port: 50000",
+		} {
+			if !strings.Contains(rendered, want) {
+				t.Errorf("rendered chart missing %q", want)
+			}
+		}
+	})
+
+	t.Run("skipped when hostNetwork is enabled", func(t *testing.T) {
+		cfg := &config.Config{HCloudToken: "test-token"}
+		cfg.Addons.Operator.Enabled = true
+		cfg.Addons.Operator.HostNetwork = true
+
+		out, err := helm.RenderFromPath(chartPath, "k8zner-operator", "k8zner-system", buildOperatorValues(cfg))
+		if err != nil {
+			t.Fatalf("failed to render operator chart: %v", err)
+		}
+
+		if strings.Contains(string(out), "NetworkPolicy") {
+			t.Error("NetworkPolicy must not render with hostNetwork: NetworkPolicies do not apply to hostNetwork pods")
+		}
+	})
+}

--- a/internal/addons/steps.go
+++ b/internal/addons/steps.go
@@ -22,6 +22,7 @@ const (
 	StepArgoCD        = "argocd"
 	StepMonitoring    = "monitoring"
 	StepTalosBackup   = "talos-backup"
+	StepLogging       = "logging"
 )
 
 // AddonStep defines a single installable addon with its install order and
@@ -44,6 +45,9 @@ var stepChartNames = map[string]string{
 	StepExternalDNS:   "external-dns",
 	StepArgoCD:        "argo-cd",
 	StepMonitoring:    "kube-prometheus-stack",
+	// The logging step installs Loki and Alloy; the Loki chart version is
+	// what gets tracked for upgrades.
+	StepLogging: "loki",
 }
 
 // stepVersion returns the desired version for a step: the resolved helm chart
@@ -77,6 +81,8 @@ func stepHelmConfig(name string, cfg *config.Config) config.HelmChartConfig {
 		return cfg.Addons.ArgoCD.Helm
 	case StepMonitoring:
 		return cfg.Addons.KubePrometheusStack.Helm
+	case StepLogging:
+		return cfg.Addons.Logging.LokiHelm
 	default:
 		return config.HelmChartConfig{}
 	}
@@ -124,6 +130,9 @@ func EnabledSteps(cfg *config.Config) []AddonStep {
 	if cfg.Addons.TalosBackup.Enabled {
 		add(StepTalosBackup, 10)
 	}
+	if cfg.Addons.Logging.Enabled {
+		add(StepLogging, 11)
+	}
 
 	return steps
 }
@@ -157,6 +166,8 @@ func InstallStep(ctx context.Context, stepName string, cfg *config.Config, kubec
 		return installMonitoringStep(ctx, client, cfg)
 	case StepTalosBackup:
 		return installTalosBackupStep(ctx, client, cfg)
+	case StepLogging:
+		return applyLogging(ctx, client, cfg)
 	default:
 		return fmt.Errorf("unknown addon step: %s", stepName)
 	}

--- a/internal/addons/steps.go
+++ b/internal/addons/steps.go
@@ -35,19 +35,26 @@ type AddonStep struct {
 	Version string
 }
 
-// stepChartNames maps step names to their helm chart registry keys.
-var stepChartNames = map[string]string{
-	StepCCM:           "hcloud-ccm",
-	StepCSI:           "hcloud-csi",
-	StepMetricsServer: "metrics-server",
-	StepCertManager:   "cert-manager",
-	StepTraefik:       "traefik",
-	StepExternalDNS:   "external-dns",
-	StepArgoCD:        "argo-cd",
-	StepMonitoring:    "kube-prometheus-stack",
+// stepChart describes how a chart-backed step resolves its desired version:
+// the helm registry key plus the user-supplied overrides from config.
+// talos-backup is the one non-chart step and is handled in stepVersion.
+type stepChart struct {
+	chartName string
+	helm      func(*config.Config) config.HelmChartConfig
+}
+
+var stepCharts = map[string]stepChart{
+	StepCCM:           {"hcloud-ccm", func(c *config.Config) config.HelmChartConfig { return c.Addons.CCM.Helm }},
+	StepCSI:           {"hcloud-csi", func(c *config.Config) config.HelmChartConfig { return c.Addons.CSI.Helm }},
+	StepMetricsServer: {"metrics-server", func(c *config.Config) config.HelmChartConfig { return c.Addons.MetricsServer.Helm }},
+	StepCertManager:   {"cert-manager", func(c *config.Config) config.HelmChartConfig { return c.Addons.CertManager.Helm }},
+	StepTraefik:       {"traefik", func(c *config.Config) config.HelmChartConfig { return c.Addons.Traefik.Helm }},
+	StepExternalDNS:   {"external-dns", func(c *config.Config) config.HelmChartConfig { return c.Addons.ExternalDNS.Helm }},
+	StepArgoCD:        {"argo-cd", func(c *config.Config) config.HelmChartConfig { return c.Addons.ArgoCD.Helm }},
+	StepMonitoring:    {"kube-prometheus-stack", func(c *config.Config) config.HelmChartConfig { return c.Addons.KubePrometheusStack.Helm }},
 	// The logging step installs Loki and Alloy; the Loki chart version is
 	// what gets tracked for upgrades.
-	StepLogging: "loki",
+	StepLogging: {"loki", func(c *config.Config) config.HelmChartConfig { return c.Addons.Logging.LokiHelm }},
 }
 
 // stepVersion returns the desired version for a step: the resolved helm chart
@@ -59,33 +66,11 @@ func stepVersion(name string, cfg *config.Config) string {
 		}
 		return talosBackupVersion()
 	}
-	return helm.GetChartSpec(stepChartNames[name], stepHelmConfig(name, cfg)).Version
-}
-
-// stepHelmConfig returns the user-supplied helm overrides for a step.
-func stepHelmConfig(name string, cfg *config.Config) config.HelmChartConfig {
-	switch name {
-	case StepCCM:
-		return cfg.Addons.CCM.Helm
-	case StepCSI:
-		return cfg.Addons.CSI.Helm
-	case StepMetricsServer:
-		return cfg.Addons.MetricsServer.Helm
-	case StepCertManager:
-		return cfg.Addons.CertManager.Helm
-	case StepTraefik:
-		return cfg.Addons.Traefik.Helm
-	case StepExternalDNS:
-		return cfg.Addons.ExternalDNS.Helm
-	case StepArgoCD:
-		return cfg.Addons.ArgoCD.Helm
-	case StepMonitoring:
-		return cfg.Addons.KubePrometheusStack.Helm
-	case StepLogging:
-		return cfg.Addons.Logging.LokiHelm
-	default:
-		return config.HelmChartConfig{}
+	chart, ok := stepCharts[name]
+	if !ok {
+		return ""
 	}
+	return helm.GetChartSpec(chart.chartName, chart.helm(cfg)).Version
 }
 
 // CNIVersion returns the desired Cilium chart version. Cilium is installed in

--- a/internal/addons/steps.go
+++ b/internal/addons/steps.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/milankappen/k8zner/internal/addons/helm"
 	"github.com/milankappen/k8zner/internal/addons/k8sclient"
 	"github.com/milankappen/k8zner/internal/config"
 )
@@ -23,10 +24,68 @@ const (
 	StepTalosBackup   = "talos-backup"
 )
 
-// AddonStep defines a single installable addon with its install order.
+// AddonStep defines a single installable addon with its install order and
+// the desired (chart) version resolved from configuration. The version is
+// recorded in cluster status on install and compared on later reconciles to
+// detect addons that need an upgrade.
 type AddonStep struct {
-	Name  string
-	Order int
+	Name    string
+	Order   int
+	Version string
+}
+
+// stepChartNames maps step names to their helm chart registry keys.
+var stepChartNames = map[string]string{
+	StepCCM:           "hcloud-ccm",
+	StepCSI:           "hcloud-csi",
+	StepMetricsServer: "metrics-server",
+	StepCertManager:   "cert-manager",
+	StepTraefik:       "traefik",
+	StepExternalDNS:   "external-dns",
+	StepArgoCD:        "argo-cd",
+	StepMonitoring:    "kube-prometheus-stack",
+}
+
+// stepVersion returns the desired version for a step: the resolved helm chart
+// version for chart-backed addons, or the pinned tool version for talos-backup.
+func stepVersion(name string, cfg *config.Config) string {
+	if name == StepTalosBackup {
+		if v := cfg.Addons.TalosBackup.Version; v != "" {
+			return v
+		}
+		return talosBackupVersion()
+	}
+	return helm.GetChartSpec(stepChartNames[name], stepHelmConfig(name, cfg)).Version
+}
+
+// stepHelmConfig returns the user-supplied helm overrides for a step.
+func stepHelmConfig(name string, cfg *config.Config) config.HelmChartConfig {
+	switch name {
+	case StepCCM:
+		return cfg.Addons.CCM.Helm
+	case StepCSI:
+		return cfg.Addons.CSI.Helm
+	case StepMetricsServer:
+		return cfg.Addons.MetricsServer.Helm
+	case StepCertManager:
+		return cfg.Addons.CertManager.Helm
+	case StepTraefik:
+		return cfg.Addons.Traefik.Helm
+	case StepExternalDNS:
+		return cfg.Addons.ExternalDNS.Helm
+	case StepArgoCD:
+		return cfg.Addons.ArgoCD.Helm
+	case StepMonitoring:
+		return cfg.Addons.KubePrometheusStack.Helm
+	default:
+		return config.HelmChartConfig{}
+	}
+}
+
+// CNIVersion returns the desired Cilium chart version. Cilium is installed in
+// the CNI phase (not via EnabledSteps) but its version is tracked the same way.
+func CNIVersion(cfg *config.Config) string {
+	return helm.GetChartSpec("cilium", cfg.Addons.Cilium.Helm).Version
 }
 
 // EnabledSteps returns the ordered list of addon steps that should be installed
@@ -34,32 +93,36 @@ type AddonStep struct {
 func EnabledSteps(cfg *config.Config) []AddonStep {
 	var steps []AddonStep
 
+	add := func(name string, order int) {
+		steps = append(steps, AddonStep{Name: name, Order: order, Version: stepVersion(name, cfg)})
+	}
+
 	if cfg.Addons.CCM.Enabled {
-		steps = append(steps, AddonStep{Name: StepCCM, Order: 2})
+		add(StepCCM, 2)
 	}
 	if cfg.Addons.CSI.Enabled {
-		steps = append(steps, AddonStep{Name: StepCSI, Order: 3})
+		add(StepCSI, 3)
 	}
 	if cfg.Addons.MetricsServer.Enabled {
-		steps = append(steps, AddonStep{Name: StepMetricsServer, Order: 4})
+		add(StepMetricsServer, 4)
 	}
 	if cfg.Addons.CertManager.Enabled {
-		steps = append(steps, AddonStep{Name: StepCertManager, Order: 5})
+		add(StepCertManager, 5)
 	}
 	if cfg.Addons.Traefik.Enabled {
-		steps = append(steps, AddonStep{Name: StepTraefik, Order: 6})
+		add(StepTraefik, 6)
 	}
 	if cfg.Addons.ExternalDNS.Enabled {
-		steps = append(steps, AddonStep{Name: StepExternalDNS, Order: 7})
+		add(StepExternalDNS, 7)
 	}
 	if cfg.Addons.ArgoCD.Enabled {
-		steps = append(steps, AddonStep{Name: StepArgoCD, Order: 8})
+		add(StepArgoCD, 8)
 	}
 	if cfg.Addons.KubePrometheusStack.Enabled {
-		steps = append(steps, AddonStep{Name: StepMonitoring, Order: 9})
+		add(StepMonitoring, 9)
 	}
 	if cfg.Addons.TalosBackup.Enabled {
-		steps = append(steps, AddonStep{Name: StepTalosBackup, Order: 10})
+		add(StepTalosBackup, 10)
 	}
 
 	return steps

--- a/internal/addons/steps.go
+++ b/internal/addons/steps.go
@@ -66,6 +66,12 @@ func stepVersion(name string, cfg *config.Config) string {
 		}
 		return talosBackupVersion()
 	}
+	// The logging step installs two charts; combine both versions so a bump
+	// to either one registers as an upgrade.
+	if name == StepLogging {
+		return helm.GetChartSpec("loki", cfg.Addons.Logging.LokiHelm).Version +
+			"+alloy-" + helm.GetChartSpec("alloy", cfg.Addons.Logging.AlloyHelm).Version
+	}
 	chart, ok := stepCharts[name]
 	if !ok {
 		return ""

--- a/internal/addons/steps_test.go
+++ b/internal/addons/steps_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milankappen/k8zner/internal/addons/helm"
 	"github.com/milankappen/k8zner/internal/config"
 )
 
@@ -329,4 +330,75 @@ func TestStepConstants(t *testing.T) {
 	assert.Equal(t, "argocd", StepArgoCD)
 	assert.Equal(t, "monitoring", StepMonitoring)
 	assert.Equal(t, "talos-backup", StepTalosBackup)
+}
+
+func TestEnabledSteps_Versions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("steps carry the resolved default chart versions", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.Config{
+			Addons: config.AddonsConfig{
+				CCM:                 config.CCMConfig{Enabled: true},
+				CSI:                 config.CSIConfig{Enabled: true},
+				MetricsServer:       config.MetricsServerConfig{Enabled: true},
+				CertManager:         config.CertManagerConfig{Enabled: true},
+				Traefik:             config.TraefikConfig{Enabled: true},
+				ExternalDNS:         config.ExternalDNSConfig{Enabled: true},
+				ArgoCD:              config.ArgoCDConfig{Enabled: true},
+				KubePrometheusStack: config.KubePrometheusStackConfig{Enabled: true},
+				TalosBackup:         config.TalosBackupConfig{Enabled: true},
+			},
+		}
+
+		versions := make(map[string]string)
+		for _, s := range EnabledSteps(cfg) {
+			versions[s.Name] = s.Version
+		}
+
+		assert.Equal(t, helm.DefaultChartSpecs["hcloud-ccm"].Version, versions[StepCCM])
+		assert.Equal(t, helm.DefaultChartSpecs["hcloud-csi"].Version, versions[StepCSI])
+		assert.Equal(t, helm.DefaultChartSpecs["metrics-server"].Version, versions[StepMetricsServer])
+		assert.Equal(t, helm.DefaultChartSpecs["cert-manager"].Version, versions[StepCertManager])
+		assert.Equal(t, helm.DefaultChartSpecs["traefik"].Version, versions[StepTraefik])
+		assert.Equal(t, helm.DefaultChartSpecs["external-dns"].Version, versions[StepExternalDNS])
+		assert.Equal(t, helm.DefaultChartSpecs["argo-cd"].Version, versions[StepArgoCD])
+		assert.Equal(t, helm.DefaultChartSpecs["kube-prometheus-stack"].Version, versions[StepMonitoring])
+		assert.Equal(t, config.DefaultVersionMatrix().TalosBackup, versions[StepTalosBackup])
+	})
+
+	t.Run("helm version overrides are respected", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.Config{
+			Addons: config.AddonsConfig{
+				Traefik:     config.TraefikConfig{Enabled: true, Helm: config.HelmChartConfig{Version: "99.0.0"}},
+				TalosBackup: config.TalosBackupConfig{Enabled: true, Version: "v9.9.9"},
+			},
+		}
+
+		versions := make(map[string]string)
+		for _, s := range EnabledSteps(cfg) {
+			versions[s.Name] = s.Version
+		}
+
+		assert.Equal(t, "99.0.0", versions[StepTraefik])
+		assert.Equal(t, "v9.9.9", versions[StepTalosBackup])
+	})
+}
+
+func TestCNIVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to registry version", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.Config{}
+		assert.Equal(t, helm.DefaultChartSpecs["cilium"].Version, CNIVersion(cfg))
+	})
+
+	t.Run("respects helm override", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.Config{}
+		cfg.Addons.Cilium.Helm.Version = "1.99.0"
+		assert.Equal(t, "1.99.0", CNIVersion(cfg))
+	})
 }

--- a/internal/addons/traefik.go
+++ b/internal/addons/traefik.go
@@ -21,7 +21,13 @@ func applyTraefik(ctx context.Context, client k8sclient.Client, cfg *config.Conf
 	// Build Traefik Helm chart values
 	values := buildTraefikValues(cfg)
 
-	return installHelmAddon(ctx, client, "traefik", "traefik", cfg.Addons.Traefik.Helm, values)
+	if err := installHelmAddon(ctx, client, "traefik", "traefik", cfg.Addons.Traefik.Helm, values); err != nil {
+		return err
+	}
+
+	// The wildcard certificate's default TLSStore depends on Traefik's CRDs,
+	// so it is applied here rather than in the cert-manager step.
+	return applyWildcardCertificate(ctx, client, cfg)
 }
 
 // buildTraefikValues creates helm values for Traefik configuration.

--- a/internal/config/addon_types.go
+++ b/internal/config/addon_types.go
@@ -29,6 +29,7 @@ type AddonsConfig struct {
 	GatewayAPICRDs         GatewayAPICRDsConfig         `mapstructure:"gateway_api_crds" yaml:"gateway_api_crds"`
 	PrometheusOperatorCRDs PrometheusOperatorCRDsConfig `mapstructure:"prometheus_operator_crds" yaml:"prometheus_operator_crds"`
 	KubePrometheusStack    KubePrometheusStackConfig    `mapstructure:"kube_prometheus_stack" yaml:"kube_prometheus_stack"`
+	Logging                LoggingConfig                `mapstructure:"logging" yaml:"logging"`
 	TalosCCM               TalosCCMConfig               `mapstructure:"talos_ccm" yaml:"talos_ccm"`
 	Cloudflare             CloudflareConfig             `mapstructure:"cloudflare" yaml:"cloudflare"`
 	ExternalDNS            ExternalDNSConfig            `mapstructure:"external_dns" yaml:"external_dns"`
@@ -171,6 +172,23 @@ type CertManagerCloudflareConfig struct {
 	// sets it as the Traefik default, so ingresses without an explicit TLS
 	// secret are covered without per-host certificates.
 	WildcardCertificate bool `mapstructure:"wildcard_certificate" yaml:"wildcard_certificate"`
+}
+
+// LoggingConfig defines the Loki + Alloy log aggregation stack.
+// Loki runs as a single binary with persistent filesystem storage; Alloy
+// tails pod logs via the Kubernetes API and pushes them to Loki.
+type LoggingConfig struct {
+	// Enabled installs the logging stack.
+	Enabled bool `mapstructure:"enabled" yaml:"enabled"`
+
+	// Retention is how long Loki keeps logs (default: 168h).
+	Retention string `mapstructure:"retention" yaml:"retention"`
+
+	// LokiHelm customizes the Loki chart.
+	LokiHelm HelmChartConfig `mapstructure:"loki_helm" yaml:"loki_helm"`
+
+	// AlloyHelm customizes the Alloy chart.
+	AlloyHelm HelmChartConfig `mapstructure:"alloy_helm" yaml:"alloy_helm"`
 }
 
 // TraefikConfig defines the Traefik Proxy ingress controller configuration.

--- a/internal/config/addon_types.go
+++ b/internal/config/addon_types.go
@@ -166,6 +166,11 @@ type CertManagerCloudflareConfig struct {
 	// Production uses Let's Encrypt production server (default: false = staging).
 	// Set to true only after testing with staging to avoid rate limits.
 	Production bool `mapstructure:"production" yaml:"production"`
+
+	// WildcardCertificate additionally issues a "*.{domain}" certificate and
+	// sets it as the Traefik default, so ingresses without an explicit TLS
+	// secret are covered without per-host certificates.
+	WildcardCertificate bool `mapstructure:"wildcard_certificate" yaml:"wildcard_certificate"`
 }
 
 // TraefikConfig defines the Traefik Proxy ingress controller configuration.

--- a/internal/config/addon_types.go
+++ b/internal/config/addon_types.go
@@ -174,6 +174,11 @@ type CertManagerCloudflareConfig struct {
 	WildcardCertificate bool `mapstructure:"wildcard_certificate" yaml:"wildcard_certificate"`
 }
 
+// LoggingDefaultRetention is how long Loki keeps logs unless overridden.
+// Both expansion paths (CLI spec and operator CRD) and the addon installer
+// reference this single constant.
+const LoggingDefaultRetention = "168h"
+
 // LoggingConfig defines the Loki + Alloy log aggregation stack.
 // Loki runs as a single binary with persistent filesystem storage; Alloy
 // tails pod logs via the Kubernetes API and pushes them to Loki.

--- a/internal/config/spec.go
+++ b/internal/config/spec.go
@@ -61,6 +61,10 @@ type Spec struct {
 	// Default: false
 	Monitoring bool `yaml:"monitoring,omitempty"`
 
+	// Logging enables the Loki + Alloy log aggregation stack.
+	// Logs are kept for 168h by default and stored on a persistent volume.
+	Logging bool `yaml:"logging,omitempty"`
+
 	// GrafanaSubdomain is the subdomain for Grafana dashboard (default: "grafana").
 	// Only used when both Monitoring and Domain are set.
 	// Example: with Domain="example.com", Grafana is at grafana.example.com

--- a/internal/config/spec.go
+++ b/internal/config/spec.go
@@ -35,6 +35,11 @@ type Spec struct {
 	// Requires CF_API_TOKEN environment variable.
 	Domain string `yaml:"domain,omitempty"`
 
+	// WildcardCertificate additionally issues a "*.{domain}" certificate via
+	// DNS01 and sets it as Traefik's default, so ingresses without an
+	// explicit TLS secret are covered. Only used when Domain is set.
+	WildcardCertificate bool `yaml:"wildcard_certificate,omitempty"`
+
 	// ArgoSubdomain is the subdomain for ArgoCD dashboard (default: "argo").
 	// When Domain is set, ArgoCD will be accessible at {ArgoSubdomain}.{Domain}.
 	// Example: with Domain="example.com" and ArgoSubdomain="argo", ArgoCD is at argo.example.com

--- a/internal/config/spec_expand.go
+++ b/internal/config/spec_expand.go
@@ -177,9 +177,10 @@ func expandAddons(cfg *Spec, vm VersionMatrix) AddonsConfig {
 		CertManager: CertManagerConfig{
 			Enabled: true,
 			Cloudflare: CertManagerCloudflareConfig{
-				Enabled:    hasDomain,
-				Email:      cfg.GetCertEmail(),
-				Production: true, // Use production Let's Encrypt
+				Enabled:             hasDomain,
+				Email:               cfg.GetCertEmail(),
+				Production:          true, // Use production Let's Encrypt
+				WildcardCertificate: hasDomain && cfg.WildcardCertificate,
 			},
 		},
 

--- a/internal/config/spec_expand.go
+++ b/internal/config/spec_expand.go
@@ -220,6 +220,12 @@ func expandAddons(cfg *Spec, vm VersionMatrix) AddonsConfig {
 
 		// Talos Backup - enabled only when backup is set
 		TalosBackup: expandTalosBackup(cfg),
+
+		// Logging (Loki + Alloy) - enabled only when logging is set
+		Logging: LoggingConfig{
+			Enabled:   cfg.Logging,
+			Retention: "168h",
+		},
 	}
 }
 

--- a/internal/config/spec_expand.go
+++ b/internal/config/spec_expand.go
@@ -224,7 +224,7 @@ func expandAddons(cfg *Spec, vm VersionMatrix) AddonsConfig {
 		// Logging (Loki + Alloy) - enabled only when logging is set
 		Logging: LoggingConfig{
 			Enabled:   cfg.Logging,
-			Retention: "168h",
+			Retention: LoggingDefaultRetention,
 		},
 	}
 }

--- a/internal/config/spec_expand_test.go
+++ b/internal/config/spec_expand_test.go
@@ -780,3 +780,59 @@ func TestExpandSpec_MonitoringCustomGrafanaSubdomain(t *testing.T) {
 			expanded.Addons.KubePrometheusStack.Grafana.IngressHost)
 	}
 }
+
+func TestExpandSpec_WildcardCertificate(t *testing.T) {
+	t.Parallel()
+
+	base := func() *Spec {
+		return &Spec{
+			Name:    "test",
+			Region:  RegionFalkenstein,
+			Mode:    ModeDev,
+			Workers: WorkerSpec{Count: 1, Size: SizeCX22},
+		}
+	}
+
+	t.Run("disabled by default even with domain", func(t *testing.T) {
+		t.Parallel()
+		spec := base()
+		spec.Domain = "example.com"
+
+		expanded, err := ExpandSpec(spec)
+		if err != nil {
+			t.Fatalf("ExpandSpec failed: %v", err)
+		}
+		if expanded.Addons.CertManager.Cloudflare.WildcardCertificate {
+			t.Error("wildcard certificate should be opt-in")
+		}
+	})
+
+	t.Run("enabled with domain", func(t *testing.T) {
+		t.Parallel()
+		spec := base()
+		spec.Domain = "example.com"
+		spec.WildcardCertificate = true
+
+		expanded, err := ExpandSpec(spec)
+		if err != nil {
+			t.Fatalf("ExpandSpec failed: %v", err)
+		}
+		if !expanded.Addons.CertManager.Cloudflare.WildcardCertificate {
+			t.Error("wildcard certificate should be enabled when requested with a domain")
+		}
+	})
+
+	t.Run("ignored without domain", func(t *testing.T) {
+		t.Parallel()
+		spec := base()
+		spec.WildcardCertificate = true
+
+		expanded, err := ExpandSpec(spec)
+		if err != nil {
+			t.Fatalf("ExpandSpec failed: %v", err)
+		}
+		if expanded.Addons.CertManager.Cloudflare.WildcardCertificate {
+			t.Error("wildcard needs a domain for DNS01")
+		}
+	})
+}

--- a/internal/config/spec_expand_test.go
+++ b/internal/config/spec_expand_test.go
@@ -836,3 +836,44 @@ func TestExpandSpec_WildcardCertificate(t *testing.T) {
 		}
 	})
 }
+
+func TestExpandSpec_Logging(t *testing.T) {
+	t.Parallel()
+
+	base := func() *Spec {
+		return &Spec{
+			Name:    "test",
+			Region:  RegionFalkenstein,
+			Mode:    ModeDev,
+			Workers: WorkerSpec{Count: 1, Size: SizeCX22},
+		}
+	}
+
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Parallel()
+		expanded, err := ExpandSpec(base())
+		if err != nil {
+			t.Fatalf("ExpandSpec failed: %v", err)
+		}
+		if expanded.Addons.Logging.Enabled {
+			t.Error("logging should be opt-in")
+		}
+	})
+
+	t.Run("enabled with default retention", func(t *testing.T) {
+		t.Parallel()
+		spec := base()
+		spec.Logging = true
+
+		expanded, err := ExpandSpec(spec)
+		if err != nil {
+			t.Fatalf("ExpandSpec failed: %v", err)
+		}
+		if !expanded.Addons.Logging.Enabled {
+			t.Error("logging should be enabled when requested")
+		}
+		if expanded.Addons.Logging.Retention != "168h" {
+			t.Errorf("expected default retention 168h, got %q", expanded.Addons.Logging.Retention)
+		}
+	})
+}

--- a/internal/operator/controller/cluster_controller.go
+++ b/internal/operator/controller/cluster_controller.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
+	"github.com/milankappen/k8zner/internal/addons"
+	"github.com/milankappen/k8zner/internal/config"
 	operatorprov "github.com/milankappen/k8zner/internal/operator/provisioning"
 	"github.com/milankappen/k8zner/internal/platform/hcloud"
 )
@@ -113,6 +115,10 @@ type ClusterReconciler struct {
 	// Defaults to waitForK8sNodeReady. Can be overridden in tests.
 	nodeReadyWaiter func(ctx context.Context, nodeName string, timeout time.Duration) error
 
+	// addonInstaller installs or upgrades a single addon step.
+	// Defaults to addons.InstallStep. Can be overridden in tests.
+	addonInstaller func(ctx context.Context, stepName string, cfg *config.Config, kubeconfig []byte, networkID int64) error
+
 	// Provisioning adapter for operator-driven provisioning.
 	phaseAdapter *operatorprov.PhaseAdapter
 
@@ -186,6 +192,14 @@ func WithNodeReadyWaiter(waiter func(ctx context.Context, nodeName string, timeo
 	}
 }
 
+// WithAddonInstaller sets a custom addon install function.
+// This is primarily used for testing to avoid installing real addons.
+func WithAddonInstaller(installer func(ctx context.Context, stepName string, cfg *config.Config, kubeconfig []byte, networkID int64) error) Option {
+	return func(r *ClusterReconciler) {
+		r.addonInstaller = installer
+	}
+}
+
 // NewClusterReconciler creates a new ClusterReconciler with the given options.
 func NewClusterReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, opts ...Option) *ClusterReconciler {
 	r := &ClusterReconciler{
@@ -204,6 +218,11 @@ func NewClusterReconciler(c client.Client, scheme *runtime.Scheme, recorder reco
 	// Set default nodeReadyWaiter if not overridden
 	if r.nodeReadyWaiter == nil {
 		r.nodeReadyWaiter = r.waitForK8sNodeReady
+	}
+
+	// Set default addonInstaller if not overridden
+	if r.addonInstaller == nil {
+		r.addonInstaller = addons.InstallStep
 	}
 
 	return r

--- a/internal/operator/controller/cluster_controller.go
+++ b/internal/operator/controller/cluster_controller.go
@@ -4,6 +4,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -16,9 +17,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
@@ -574,8 +577,39 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8znerv1alpha1.K8znerCluster{}).
-		Watches(&corev1.Node{}, &nodeEventHandler{client: mgr.GetClient()}).
+		Watches(&corev1.Node{}, &nodeEventHandler{client: mgr.GetClient()},
+			builder.WithPredicates(nodeChangePredicate())).
 		Complete(r)
+}
+
+// nodeChangePredicate filters node update events down to changes that can
+// affect reconciliation: readiness transitions, schedulability, labels, and
+// deletion. Without it, every kubelet heartbeat (one status update per node
+// every ~10s) re-enqueues the cluster and floods the workqueue.
+func nodeChangePredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, okOld := e.ObjectOld.(*corev1.Node)
+			newNode, okNew := e.ObjectNew.(*corev1.Node)
+			if !okOld || !okNew {
+				return true
+			}
+			return nodeReadyStatus(oldNode) != nodeReadyStatus(newNode) ||
+				oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable ||
+				oldNode.DeletionTimestamp.IsZero() != newNode.DeletionTimestamp.IsZero() ||
+				!maps.Equal(oldNode.Labels, newNode.Labels)
+		},
+	}
+}
+
+// nodeReadyStatus returns the status of the node's Ready condition.
+func nodeReadyStatus(node *corev1.Node) corev1.ConditionStatus {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status
+		}
+	}
+	return corev1.ConditionUnknown
 }
 
 // nodeEventHandler handles node events and triggers reconciliation.

--- a/internal/operator/controller/cluster_controller.go
+++ b/internal/operator/controller/cluster_controller.go
@@ -253,6 +253,16 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	// The operator does not register a finalizer: deleting a K8znerCluster
+	// intentionally leaves cloud infrastructure intact (tear-down is an
+	// explicit action via `k8zner destroy` or the cleanup utility). Skip
+	// reconciliation so a deleting cluster is not provisioned or healed
+	// while the object disappears.
+	if !cluster.DeletionTimestamp.IsZero() {
+		logger.Info("cluster is being deleted, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	// Check if paused
 	if cluster.Spec.Paused {
 		logger.Info("cluster is paused, skipping reconciliation")
@@ -327,7 +337,11 @@ func (r *ClusterReconciler) updateStatusWithRetry(ctx context.Context, cluster *
 		}
 		cluster = latest
 
-		time.Sleep(statusRetryInterval)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(statusRetryInterval):
+		}
 	}
 
 	return fmt.Errorf("failed to update status after %d retries", statusUpdateRetries)
@@ -560,12 +574,14 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8znerv1alpha1.K8znerCluster{}).
-		Watches(&corev1.Node{}, &nodeEventHandler{}).
+		Watches(&corev1.Node{}, &nodeEventHandler{client: mgr.GetClient()}).
 		Complete(r)
 }
 
 // nodeEventHandler handles node events and triggers reconciliation.
-type nodeEventHandler struct{}
+type nodeEventHandler struct {
+	client client.Client
+}
 
 // Create enqueues the cluster for reconciliation on node creation.
 func (h *nodeEventHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -588,12 +604,20 @@ func (h *nodeEventHandler) Generic(ctx context.Context, e event.GenericEvent, q 
 }
 
 func (h *nodeEventHandler) enqueueCluster(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	// Enqueue all K8znerCluster resources in the k8zner-system namespace
-	// In a real implementation, we'd look up which cluster owns this node
-	q.Add(reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: "k8zner-system",
-			Name:      "cluster",
-		},
-	})
+	// Node objects carry no owner reference back to a K8znerCluster, so
+	// enqueue every cluster and let each reconcile sort out relevance.
+	// In practice a management cluster hosts a single K8znerCluster.
+	clusters := &k8znerv1alpha1.K8znerClusterList{}
+	if err := h.client.List(ctx, clusters); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list K8znerClusters for node event")
+		return
+	}
+	for i := range clusters.Items {
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: clusters.Items[i].Namespace,
+				Name:      clusters.Items[i].Name,
+			},
+		})
+	}
 }

--- a/internal/operator/controller/cluster_controller.go
+++ b/internal/operator/controller/cluster_controller.go
@@ -240,6 +240,8 @@ func (r *ClusterReconciler) ensureHCloudClient() error {
 	return nil
 }
 
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;update;patch,resourceNames=k8znerclusters.k8zner.io
 // +kubebuilder:rbac:groups=k8zner.io,resources=k8znerclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=k8zner.io,resources=k8znerclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=k8zner.io,resources=k8znerclusters/finalizers,verbs=update

--- a/internal/operator/controller/cluster_controller_test.go
+++ b/internal/operator/controller/cluster_controller_test.go
@@ -142,6 +142,40 @@ func TestClusterReconciler_Reconcile(t *testing.T) {
 		assert.Equal(t, ctrl.Result{}, result)
 	})
 
+	t.Run("deleting cluster skips reconciliation", func(t *testing.T) {
+		t.Parallel()
+		scheme := setupTestScheme(t)
+		cluster := &k8znerv1alpha1.K8znerCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-cluster",
+				Namespace:         "default",
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{"test.k8zner.io/keep"},
+			},
+		}
+
+		client := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(cluster).
+			WithStatusSubresource(cluster).
+			Build()
+		recorder := record.NewFakeRecorder(10)
+
+		r := NewClusterReconciler(client, scheme, recorder,
+			WithHCloudClient(&MockHCloudClient{}),
+		)
+
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "default",
+				Name:      "test-cluster",
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+	})
+
 	t.Run("paused cluster skips reconciliation", func(t *testing.T) {
 		t.Parallel()
 		scheme := setupTestScheme(t)
@@ -379,7 +413,30 @@ func TestGenerateReplacementServerName(t *testing.T) {
 
 func TestNodeEventHandler(t *testing.T) {
 	t.Parallel()
-	h := &nodeEventHandler{}
+	scheme := setupTestScheme(t)
+
+	newCluster := func(namespace, name string) *k8znerv1alpha1.K8znerCluster {
+		return &k8znerv1alpha1.K8znerCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		}
+	}
+
+	h := &nodeEventHandler{
+		client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(newCluster("k8zner-system", "my-cluster")).
+			Build(),
+	}
+
+	expectEnqueued := func(t *testing.T, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		t.Helper()
+		assert.Equal(t, 1, q.Len())
+
+		item, _ := q.Get()
+		assert.Equal(t, "k8zner-system", item.Namespace)
+		assert.Equal(t, "my-cluster", item.Name)
+		q.Done(item)
+	}
 
 	t.Run("Create enqueues cluster", func(t *testing.T) {
 		t.Parallel()
@@ -387,12 +444,7 @@ func TestNodeEventHandler(t *testing.T) {
 		defer q.ShutDown()
 
 		h.Create(context.Background(), event.CreateEvent{}, q)
-		assert.Equal(t, 1, q.Len())
-
-		item, _ := q.Get()
-		assert.Equal(t, "k8zner-system", item.Namespace)
-		assert.Equal(t, "cluster", item.Name)
-		q.Done(item)
+		expectEnqueued(t, q)
 	})
 
 	t.Run("Update enqueues cluster", func(t *testing.T) {
@@ -401,12 +453,7 @@ func TestNodeEventHandler(t *testing.T) {
 		defer q.ShutDown()
 
 		h.Update(context.Background(), event.UpdateEvent{}, q)
-		assert.Equal(t, 1, q.Len())
-
-		item, _ := q.Get()
-		assert.Equal(t, "k8zner-system", item.Namespace)
-		assert.Equal(t, "cluster", item.Name)
-		q.Done(item)
+		expectEnqueued(t, q)
 	})
 
 	t.Run("Delete enqueues cluster", func(t *testing.T) {
@@ -415,12 +462,7 @@ func TestNodeEventHandler(t *testing.T) {
 		defer q.ShutDown()
 
 		h.Delete(context.Background(), event.DeleteEvent{}, q)
-		assert.Equal(t, 1, q.Len())
-
-		item, _ := q.Get()
-		assert.Equal(t, "k8zner-system", item.Namespace)
-		assert.Equal(t, "cluster", item.Name)
-		q.Done(item)
+		expectEnqueued(t, q)
 	})
 
 	t.Run("Generic enqueues cluster", func(t *testing.T) {
@@ -429,12 +471,26 @@ func TestNodeEventHandler(t *testing.T) {
 		defer q.ShutDown()
 
 		h.Generic(context.Background(), event.GenericEvent{}, q)
-		assert.Equal(t, 1, q.Len())
+		expectEnqueued(t, q)
+	})
 
-		item, _ := q.Get()
-		assert.Equal(t, "k8zner-system", item.Namespace)
-		assert.Equal(t, "cluster", item.Name)
-		q.Done(item)
+	t.Run("enqueues every cluster across namespaces", func(t *testing.T) {
+		t.Parallel()
+		multi := &nodeEventHandler{
+			client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(
+					newCluster("k8zner-system", "cluster-a"),
+					newCluster("other-ns", "cluster-b"),
+				).
+				Build(),
+		}
+
+		q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+		defer q.ShutDown()
+
+		multi.Create(context.Background(), event.CreateEvent{}, q)
+		assert.Equal(t, 2, q.Len())
 	})
 }
 

--- a/internal/operator/controller/cluster_controller_test.go
+++ b/internal/operator/controller/cluster_controller_test.go
@@ -411,6 +411,59 @@ func TestGenerateReplacementServerName(t *testing.T) {
 	})
 }
 
+func TestNodeChangePredicate(t *testing.T) {
+	t.Parallel()
+	pred := nodeChangePredicate()
+
+	readyNode := func() *corev1.Node { return createTestNode("node-1", false, true) }
+	notReadyNode := func() *corev1.Node { return createTestNode("node-1", false, false) }
+
+	update := func(oldNode, newNode *corev1.Node) event.UpdateEvent {
+		return event.UpdateEvent{ObjectOld: oldNode, ObjectNew: newNode}
+	}
+
+	t.Run("ignores heartbeat-only updates", func(t *testing.T) {
+		t.Parallel()
+		oldNode, newNode := readyNode(), readyNode()
+		newNode.Status.Conditions[0].LastHeartbeatTime = metav1.Now()
+		newNode.ResourceVersion = "2"
+		assert.False(t, pred.Update(update(oldNode, newNode)))
+	})
+
+	t.Run("enqueues on readiness transition", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, pred.Update(update(readyNode(), notReadyNode())))
+		assert.True(t, pred.Update(update(notReadyNode(), readyNode())))
+	})
+
+	t.Run("enqueues on unschedulable change", func(t *testing.T) {
+		t.Parallel()
+		cordoned := readyNode()
+		cordoned.Spec.Unschedulable = true
+		assert.True(t, pred.Update(update(readyNode(), cordoned)))
+	})
+
+	t.Run("enqueues on label change", func(t *testing.T) {
+		t.Parallel()
+		labeled := readyNode()
+		labeled.Labels = map[string]string{"node-role.kubernetes.io/control-plane": ""}
+		assert.True(t, pred.Update(update(readyNode(), labeled)))
+	})
+
+	t.Run("enqueues on deletion timestamp", func(t *testing.T) {
+		t.Parallel()
+		deleting := readyNode()
+		deleting.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		assert.True(t, pred.Update(update(readyNode(), deleting)))
+	})
+
+	t.Run("create and delete pass through", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, pred.Create(event.CreateEvent{Object: readyNode()}))
+		assert.True(t, pred.Delete(event.DeleteEvent{Object: readyNode()}))
+	})
+}
+
 func TestNodeEventHandler(t *testing.T) {
 	t.Parallel()
 	scheme := setupTestScheme(t)

--- a/internal/operator/controller/crd_selfapply_integration_test.go
+++ b/internal/operator/controller/crd_selfapply_integration_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/milankappen/k8zner/internal/operator/crds"
@@ -18,7 +18,9 @@ import (
 // CRD exists — the situation every operator restart hits.
 var _ = Describe("CRD self-apply", func() {
 	It("server-side-applies the embedded CRD idempotently", func() {
-		s := scheme.Scheme
+		// A private scheme: mutating the shared client-go scheme.Scheme here
+		// would race with the manager's decoders running in the background.
+		s := runtime.NewScheme()
 		Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
 
 		directClient, err := client.New(cfg, client.Options{Scheme: s})

--- a/internal/operator/controller/crd_selfapply_integration_test.go
+++ b/internal/operator/controller/crd_selfapply_integration_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/milankappen/k8zner/internal/operator/crds"
+)
+
+// The envtest apiserver already has the CRD installed from config/crd/bases,
+// so this exercises the startup self-apply path against a server where the
+// CRD exists — the situation every operator restart hits.
+var _ = Describe("CRD self-apply", func() {
+	It("server-side-applies the embedded CRD idempotently", func() {
+		s := scheme.Scheme
+		Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
+
+		directClient, err := client.New(cfg, client.Options{Scheme: s})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Applying twice must not conflict: startup runs on every restart.
+		Expect(crds.Ensure(ctx, directClient)).To(Succeed())
+		Expect(crds.Ensure(ctx, directClient)).To(Succeed())
+
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		Expect(directClient.Get(ctx, types.NamespacedName{Name: "k8znerclusters.k8zner.io"}, crd)).To(Succeed())
+
+		owners := make([]string, 0, len(crd.ManagedFields))
+		for _, mf := range crd.ManagedFields {
+			owners = append(owners, mf.Manager)
+		}
+		Expect(owners).To(ContainElement("k8zner-operator"))
+	})
+})

--- a/internal/operator/controller/crd_validation_integration_test.go
+++ b/internal/operator/controller/crd_validation_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package controller
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
+)
+
+// These tests exercise the CRD schema served by the envtest apiserver
+// (installed from config/crd/bases), so they cover the validation rules end
+// to end: enums, patterns, and CEL immutability rules.
+var _ = Describe("K8znerCluster CRD validation", func() {
+	newValidCluster := func(name string) *k8znerv1alpha1.K8znerCluster {
+		return &k8znerv1alpha1.K8znerCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+			Spec: k8znerv1alpha1.K8znerClusterSpec{
+				Region:        "fsn1",
+				ControlPlanes: k8znerv1alpha1.ControlPlaneSpec{Count: 1, Size: "cx22"},
+				Workers:       k8znerv1alpha1.WorkerSpec{Count: 1, Size: "cx22"},
+				Kubernetes:    k8znerv1alpha1.KubernetesSpec{Version: "1.32.0"},
+				Talos:         k8znerv1alpha1.TalosSpec{Version: "v1.10.0"},
+				Paused:        true, // keep the reconciler out of these tests
+			},
+		}
+	}
+
+	var counter int
+	var cluster *k8znerv1alpha1.K8znerCluster
+
+	BeforeEach(func() {
+		counter++
+		cluster = newValidCluster(fmt.Sprintf("crd-validation-%d-%d", GinkgoRandomSeed(), counter))
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, cluster)
+	})
+
+	It("rejects an invalid domain", func() {
+		cluster.Spec.Domain = "Not_A_Domain!"
+		Expect(k8sClient.Create(ctx, cluster)).NotTo(Succeed())
+	})
+
+	It("rejects an invalid subdomain", func() {
+		cluster.Spec.Domain = "example.com"
+		cluster.Spec.Addons = &k8znerv1alpha1.AddonSpec{ArgoSubdomain: "bad.subdomain"}
+		Expect(k8sClient.Create(ctx, cluster)).NotTo(Succeed())
+	})
+
+	It("accepts a valid domain and subdomain", func() {
+		cluster.Spec.Domain = "example.com"
+		cluster.Spec.Addons = &k8znerv1alpha1.AddonSpec{ArgoSubdomain: "argo-test"}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+	})
+
+	It("rejects changing the region after creation", func() {
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+		cluster.Spec.Region = "nbg1"
+		err := k8sClient.Update(ctx, cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("region is immutable"))
+	})
+
+	It("allows setting credentialsRef when previously empty, then freezes it", func() {
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+
+		cluster.Spec.CredentialsRef.Name = "my-credentials"
+		Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+
+		cluster.Spec.CredentialsRef.Name = "other-credentials"
+		err := k8sClient.Update(ctx, cluster)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("credentialsRef is immutable"))
+	})
+})

--- a/internal/operator/controller/reconcile_addon_upgrades.go
+++ b/internal/operator/controller/reconcile_addon_upgrades.go
@@ -1,0 +1,170 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
+	"github.com/milankappen/k8zner/internal/addons"
+	"github.com/milankappen/k8zner/internal/config"
+)
+
+// Addon upgrade event reasons.
+const (
+	EventReasonAddonUpgrading     = "AddonUpgrading"
+	EventReasonAddonUpgraded      = "AddonUpgraded"
+	EventReasonAddonUpgradeFailed = "AddonUpgradeFailed"
+)
+
+// reconcileAddonUpgrades keeps installed addons converged on their desired
+// versions while the cluster is running. It backfills missing version records,
+// upgrades one outdated addon per reconcile (re-rendering and re-applying its
+// manifests), and installs addons that were enabled in the spec after
+// provisioning completed.
+//
+// Cilium is deliberately excluded: CNI upgrades affect every pod on the
+// cluster and are not attempted automatically.
+//
+// Returns handled=true when it acted (the caller should requeue with the
+// returned result instead of continuing).
+func (r *ClusterReconciler) reconcileAddonUpgrades(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster) (ctrl.Result, bool) {
+	logger := log.FromContext(ctx)
+
+	// Never upgrade a cluster that is scaling, healing, or otherwise not at
+	// full strength: converging versions can wait, quorum cannot.
+	if !clusterStableForUpgrades(cluster) {
+		return ctrl.Result{}, false
+	}
+
+	cfg, kubeconfig, networkID, err := r.prepareAddonInputs(ctx, cluster)
+	if err != nil {
+		// Non-fatal: upgrades are retried on the next periodic reconcile.
+		logger.V(1).Info("skipping addon upgrade check", "reason", err.Error())
+		return ctrl.Result{}, false
+	}
+
+	return r.applyAddonPlan(ctx, cluster, addons.EnabledSteps(cfg), cfg, kubeconfig, networkID)
+}
+
+// clusterStableForUpgrades reports whether all desired nodes are ready.
+func clusterStableForUpgrades(cluster *k8znerv1alpha1.K8znerCluster) bool {
+	return cluster.Status.ControlPlanes.Ready >= cluster.Status.ControlPlanes.Desired &&
+		cluster.Status.Workers.Ready >= cluster.Status.Workers.Desired
+}
+
+// planAddonReconcile compares desired steps against recorded addon statuses.
+// It returns version backfills (addons installed before version tracking
+// existed: recorded as installed but with no version) and the first step that
+// needs an install or upgrade. Backfills never trigger a reinstall — we assume
+// the version that installed them is the one currently pinned.
+func planAddonReconcile(steps []addons.AddonStep, statuses map[string]k8znerv1alpha1.AddonStatus) (map[string]string, *addons.AddonStep) {
+	backfills := make(map[string]string)
+
+	for i := range steps {
+		step := steps[i]
+		status, exists := statuses[step.Name]
+
+		if !exists {
+			// Enabled after provisioning completed — install it.
+			return backfills, &step
+		}
+
+		switch status.Phase {
+		case k8znerv1alpha1.AddonPhaseInstalled:
+			if status.Version == "" {
+				backfills[step.Name] = step.Version
+				continue
+			}
+			if status.Version != step.Version {
+				return backfills, &step
+			}
+		case k8znerv1alpha1.AddonPhaseFailed, k8znerv1alpha1.AddonPhaseUpgrading:
+			if status.Version != step.Version {
+				return backfills, &step
+			}
+		default:
+			// Pending/Installing belong to the provisioning state machine.
+		}
+	}
+
+	return backfills, nil
+}
+
+// applyAddonPlan executes the result of planAddonReconcile: it records version
+// backfills and performs at most one addon install/upgrade per reconcile.
+func (r *ClusterReconciler) applyAddonPlan(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster, steps []addons.AddonStep, cfg *config.Config, kubeconfig []byte, networkID int64) (ctrl.Result, bool) {
+	logger := log.FromContext(ctx)
+
+	if cluster.Status.Addons == nil {
+		cluster.Status.Addons = make(map[string]k8znerv1alpha1.AddonStatus)
+	}
+
+	backfills, next := planAddonReconcile(steps, cluster.Status.Addons)
+
+	for name, version := range backfills {
+		status := cluster.Status.Addons[name]
+		status.Version = version
+		cluster.Status.Addons[name] = status
+		logger.Info("backfilled addon version", "addon", name, "version", version)
+	}
+
+	if next == nil {
+		if len(backfills) > 0 {
+			return ctrl.Result{Requeue: true}, true
+		}
+		return ctrl.Result{}, false
+	}
+
+	previous := cluster.Status.Addons[next.Name]
+
+	logger.Info("upgrading addon", "addon", next.Name,
+		"from", previous.Version, "to", next.Version)
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventReasonAddonUpgrading,
+		"Upgrading addon %s from %q to %q", next.Name, previous.Version, next.Version)
+
+	now := metav1.Now()
+	upgrading := previous
+	upgrading.Phase = k8znerv1alpha1.AddonPhaseUpgrading
+	upgrading.LastTransitionTime = &now
+	cluster.Status.Addons[next.Name] = upgrading
+
+	startedAt := metav1.Now()
+	if err := r.addonInstaller(ctx, next.Name, cfg, kubeconfig, networkID); err != nil {
+		r.logAndRecordError(ctx, cluster, err, EventReasonAddonUpgradeFailed,
+			"Failed to upgrade addon: "+next.Name)
+		recordPhaseError(cluster, next.Name, err.Error())
+
+		failed := previous
+		failed.Phase = k8znerv1alpha1.AddonPhaseFailed
+		failed.RetryCount = previous.RetryCount + 1
+		failed.Message = err.Error()
+		failureTime := metav1.Now()
+		failed.LastTransitionTime = &failureTime
+		cluster.Status.Addons[next.Name] = failed
+
+		return ctrl.Result{RequeueAfter: addonRetryBackoff(failed.RetryCount)}, true
+	}
+
+	finished := metav1.Now()
+	cluster.Status.Addons[next.Name] = k8znerv1alpha1.AddonStatus{
+		Installed:          true,
+		Healthy:            true,
+		Phase:              k8znerv1alpha1.AddonPhaseInstalled,
+		Version:            next.Version,
+		LastTransitionTime: &finished,
+		InstallOrder:       next.Order,
+		StartedAt:          &startedAt,
+		Duration:           finished.Sub(startedAt.Time).Round(time.Second).String(),
+	}
+
+	logger.Info("addon upgraded", "addon", next.Name, "version", next.Version)
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventReasonAddonUpgraded,
+		"Addon %s upgraded to %q", next.Name, next.Version)
+
+	return ctrl.Result{Requeue: true}, true
+}

--- a/internal/operator/controller/reconcile_addon_upgrades.go
+++ b/internal/operator/controller/reconcile_addon_upgrades.go
@@ -41,14 +41,31 @@ func (r *ClusterReconciler) reconcileAddonUpgrades(ctx context.Context, cluster 
 		return ctrl.Result{}, false
 	}
 
-	cfg, kubeconfig, networkID, err := r.prepareAddonInputs(ctx, cluster)
+	cfg, creds, err := r.addonConfig(ctx, cluster)
 	if err != nil {
 		// Non-fatal: upgrades are retried on the next periodic reconcile.
 		logger.V(1).Info("skipping addon upgrade check", "reason", err.Error())
 		return ctrl.Result{}, false
 	}
 
-	return r.applyAddonPlan(ctx, cluster, addons.EnabledSteps(cfg), cfg, kubeconfig, networkID)
+	steps := addons.EnabledSteps(cfg)
+
+	// In the common steady state everything is converged, and version
+	// backfills only mutate status. Fetching cluster access dials the Talos
+	// API, so only pay for it when an install or upgrade is actually due.
+	var kubeconfig []byte
+	var networkID int64
+	if backfills, next := planAddonReconcile(steps, cluster.Status.Addons); next != nil {
+		kubeconfig, networkID, err = r.addonClusterAccess(ctx, cluster, creds)
+		if err != nil {
+			logger.V(1).Info("skipping addon upgrade check", "reason", err.Error())
+			return ctrl.Result{}, false
+		}
+	} else if len(backfills) == 0 {
+		return ctrl.Result{}, false
+	}
+
+	return r.applyAddonPlan(ctx, cluster, steps, cfg, kubeconfig, networkID)
 }
 
 // clusterStableForUpgrades reports whether all desired nodes are ready.

--- a/internal/operator/controller/reconcile_addon_upgrades.go
+++ b/internal/operator/controller/reconcile_addon_upgrades.go
@@ -48,24 +48,27 @@ func (r *ClusterReconciler) reconcileAddonUpgrades(ctx context.Context, cluster 
 		return ctrl.Result{}, false
 	}
 
-	steps := addons.EnabledSteps(cfg)
+	if cluster.Status.Addons == nil {
+		cluster.Status.Addons = make(map[string]k8znerv1alpha1.AddonStatus)
+	}
+	backfills, next := planAddonReconcile(addons.EnabledSteps(cfg), cluster.Status.Addons)
+	if len(backfills) == 0 && next == nil {
+		return ctrl.Result{}, false
+	}
 
-	// In the common steady state everything is converged, and version
-	// backfills only mutate status. Fetching cluster access dials the Talos
-	// API, so only pay for it when an install or upgrade is actually due.
+	// Version backfills only mutate status. Fetching cluster access dials
+	// the Talos API, so only pay for it when an install or upgrade is due.
 	var kubeconfig []byte
 	var networkID int64
-	if backfills, next := planAddonReconcile(steps, cluster.Status.Addons); next != nil {
+	if next != nil {
 		kubeconfig, networkID, err = r.addonClusterAccess(ctx, cluster, creds)
 		if err != nil {
 			logger.V(1).Info("skipping addon upgrade check", "reason", err.Error())
 			return ctrl.Result{}, false
 		}
-	} else if len(backfills) == 0 {
-		return ctrl.Result{}, false
 	}
 
-	return r.applyAddonPlan(ctx, cluster, steps, cfg, kubeconfig, networkID)
+	return r.applyAddonPlan(ctx, cluster, backfills, next, cfg, kubeconfig, networkID)
 }
 
 // clusterStableForUpgrades reports whether all desired nodes are ready.
@@ -101,9 +104,9 @@ func planAddonReconcile(steps []addons.AddonStep, statuses map[string]k8znerv1al
 				return backfills, &step
 			}
 		case k8znerv1alpha1.AddonPhaseFailed, k8znerv1alpha1.AddonPhaseUpgrading:
-			if status.Version != step.Version {
-				return backfills, &step
-			}
+			// Always re-apply: a half-applied upgrade can leave Failed at
+			// the desired version, and re-rendering is the only repair.
+			return backfills, &step
 		default:
 			// Pending/Installing belong to the provisioning state machine.
 		}
@@ -112,16 +115,14 @@ func planAddonReconcile(steps []addons.AddonStep, statuses map[string]k8znerv1al
 	return backfills, nil
 }
 
-// applyAddonPlan executes the result of planAddonReconcile: it records version
+// applyAddonPlan executes a plan from planAddonReconcile: it records version
 // backfills and performs at most one addon install/upgrade per reconcile.
-func (r *ClusterReconciler) applyAddonPlan(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster, steps []addons.AddonStep, cfg *config.Config, kubeconfig []byte, networkID int64) (ctrl.Result, bool) {
+func (r *ClusterReconciler) applyAddonPlan(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster, backfills map[string]string, next *addons.AddonStep, cfg *config.Config, kubeconfig []byte, networkID int64) (ctrl.Result, bool) {
 	logger := log.FromContext(ctx)
 
 	if cluster.Status.Addons == nil {
 		cluster.Status.Addons = make(map[string]k8znerv1alpha1.AddonStatus)
 	}
-
-	backfills, next := planAddonReconcile(steps, cluster.Status.Addons)
 
 	for name, version := range backfills {
 		status := cluster.Status.Addons[name]

--- a/internal/operator/controller/reconcile_addon_upgrades_test.go
+++ b/internal/operator/controller/reconcile_addon_upgrades_test.go
@@ -111,6 +111,25 @@ func TestPlanAddonReconcile(t *testing.T) {
 		assert.Equal(t, addons.StepTraefik, next.Name)
 	})
 
+	t.Run("failed addon at the desired version is still repaired", func(t *testing.T) {
+		t.Parallel()
+		// A half-applied upgrade can leave Phase=Failed with the recorded
+		// version equal to the (reverted) desired version; re-applying the
+		// manifests is the only way back to a converged state.
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM: installed("1.29.0"),
+			addons.StepTraefik: {
+				Installed: true,
+				Phase:     k8znerv1alpha1.AddonPhaseFailed,
+				Version:   "39.0.0",
+			},
+		}
+
+		_, next := planAddonReconcile(steps, statuses)
+		require.NotNil(t, next)
+		assert.Equal(t, addons.StepTraefik, next.Name)
+	})
+
 	t.Run("addon mid-install during provisioning is left alone", func(t *testing.T) {
 		t.Parallel()
 		statuses := map[string]k8znerv1alpha1.AddonStatus{
@@ -163,7 +182,8 @@ func TestApplyAddonPlan(t *testing.T) {
 			Phase:     k8znerv1alpha1.AddonPhaseInstalled,
 		}
 
-		_, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+		backfills := map[string]string{addons.StepTraefik: "39.0.0"}
+		_, handled := r.applyAddonPlan(context.Background(), cluster, backfills, nil, &config.Config{}, nil, 0)
 
 		assert.True(t, handled)
 		assert.Zero(t, installs)
@@ -184,7 +204,7 @@ func TestApplyAddonPlan(t *testing.T) {
 			RetryCount: 3,
 		}
 
-		result, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+		result, handled := r.applyAddonPlan(context.Background(), cluster, nil, &steps[0], &config.Config{}, nil, 0)
 
 		assert.True(t, handled)
 		assert.Equal(t, addons.StepTraefik, installedName)
@@ -207,7 +227,7 @@ func TestApplyAddonPlan(t *testing.T) {
 			Version:   "38.0.0",
 		}
 
-		result, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+		result, handled := r.applyAddonPlan(context.Background(), cluster, nil, &steps[0], &config.Config{}, nil, 0)
 
 		assert.True(t, handled)
 		got := cluster.Status.Addons[addons.StepTraefik]
@@ -230,7 +250,7 @@ func TestApplyAddonPlan(t *testing.T) {
 			Version:   "39.0.0",
 		}
 
-		_, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+		_, handled := r.applyAddonPlan(context.Background(), cluster, nil, nil, &config.Config{}, nil, 0)
 		assert.False(t, handled)
 	})
 }

--- a/internal/operator/controller/reconcile_addon_upgrades_test.go
+++ b/internal/operator/controller/reconcile_addon_upgrades_test.go
@@ -1,0 +1,254 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
+	"github.com/milankappen/k8zner/internal/addons"
+	"github.com/milankappen/k8zner/internal/config"
+)
+
+func TestPlanAddonReconcile(t *testing.T) {
+	t.Parallel()
+
+	installed := func(version string) k8znerv1alpha1.AddonStatus {
+		return k8znerv1alpha1.AddonStatus{
+			Installed: true,
+			Phase:     k8znerv1alpha1.AddonPhaseInstalled,
+			Version:   version,
+		}
+	}
+
+	steps := []addons.AddonStep{
+		{Name: addons.StepCCM, Order: 2, Version: "1.29.0"},
+		{Name: addons.StepTraefik, Order: 6, Version: "39.0.0"},
+	}
+
+	t.Run("everything current means nothing to do", func(t *testing.T) {
+		t.Parallel()
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM:     installed("1.29.0"),
+			addons.StepTraefik: installed("39.0.0"),
+		}
+
+		backfills, next := planAddonReconcile(steps, statuses)
+		assert.Empty(t, backfills)
+		assert.Nil(t, next)
+	})
+
+	t.Run("empty recorded version is backfilled without reinstall", func(t *testing.T) {
+		t.Parallel()
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM:     installed(""),
+			addons.StepTraefik: installed("39.0.0"),
+		}
+
+		backfills, next := planAddonReconcile(steps, statuses)
+		assert.Equal(t, map[string]string{addons.StepCCM: "1.29.0"}, backfills)
+		assert.Nil(t, next)
+	})
+
+	t.Run("version mismatch selects the addon for upgrade", func(t *testing.T) {
+		t.Parallel()
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM:     installed("1.29.0"),
+			addons.StepTraefik: installed("38.0.0"),
+		}
+
+		backfills, next := planAddonReconcile(steps, statuses)
+		assert.Empty(t, backfills)
+		require.NotNil(t, next)
+		assert.Equal(t, addons.StepTraefik, next.Name)
+	})
+
+	t.Run("only the first outdated addon is selected per reconcile", func(t *testing.T) {
+		t.Parallel()
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM:     installed("1.0.0"),
+			addons.StepTraefik: installed("38.0.0"),
+		}
+
+		_, next := planAddonReconcile(steps, statuses)
+		require.NotNil(t, next)
+		assert.Equal(t, addons.StepCCM, next.Name, "steps are ordered; CCM upgrades first")
+	})
+
+	t.Run("newly enabled addon with no status entry is installed", func(t *testing.T) {
+		t.Parallel()
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM: installed("1.29.0"),
+		}
+
+		backfills, next := planAddonReconcile(steps, statuses)
+		assert.Empty(t, backfills)
+		require.NotNil(t, next)
+		assert.Equal(t, addons.StepTraefik, next.Name)
+	})
+
+	t.Run("previously failed upgrade is retried", func(t *testing.T) {
+		t.Parallel()
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM: installed("1.29.0"),
+			addons.StepTraefik: {
+				Installed:  true,
+				Phase:      k8znerv1alpha1.AddonPhaseFailed,
+				Version:    "38.0.0",
+				RetryCount: 2,
+			},
+		}
+
+		_, next := planAddonReconcile(steps, statuses)
+		require.NotNil(t, next)
+		assert.Equal(t, addons.StepTraefik, next.Name)
+	})
+
+	t.Run("addon mid-install during provisioning is left alone", func(t *testing.T) {
+		t.Parallel()
+		statuses := map[string]k8znerv1alpha1.AddonStatus{
+			addons.StepCCM: {
+				Phase:   k8znerv1alpha1.AddonPhaseInstalling,
+				Version: "",
+			},
+			addons.StepTraefik: installed("39.0.0"),
+		}
+
+		backfills, next := planAddonReconcile(steps, statuses)
+		assert.Empty(t, backfills)
+		assert.Nil(t, next)
+	})
+}
+
+func TestApplyAddonPlan(t *testing.T) {
+	t.Parallel()
+
+	newReconciler := func(t *testing.T, installer func(ctx context.Context, name string, cfg *config.Config, kubeconfig []byte, networkID int64) error) (*ClusterReconciler, *k8znerv1alpha1.K8znerCluster) {
+		t.Helper()
+		scheme := setupTestScheme(t)
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := NewClusterReconciler(c, scheme, record.NewFakeRecorder(20),
+			WithHCloudClient(&MockHCloudClient{}),
+			WithAddonInstaller(installer),
+		)
+		cluster := &k8znerv1alpha1.K8znerCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+			Status: k8znerv1alpha1.K8znerClusterStatus{
+				Addons: map[string]k8znerv1alpha1.AddonStatus{},
+			},
+		}
+		return r, cluster
+	}
+
+	steps := []addons.AddonStep{
+		{Name: addons.StepTraefik, Order: 6, Version: "39.0.0"},
+	}
+
+	t.Run("backfills versions without invoking the installer", func(t *testing.T) {
+		t.Parallel()
+		installs := 0
+		r, cluster := newReconciler(t, func(context.Context, string, *config.Config, []byte, int64) error {
+			installs++
+			return nil
+		})
+		cluster.Status.Addons[addons.StepTraefik] = k8znerv1alpha1.AddonStatus{
+			Installed: true,
+			Phase:     k8znerv1alpha1.AddonPhaseInstalled,
+		}
+
+		_, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+
+		assert.True(t, handled)
+		assert.Zero(t, installs)
+		assert.Equal(t, "39.0.0", cluster.Status.Addons[addons.StepTraefik].Version)
+	})
+
+	t.Run("successful upgrade records new version and resets retries", func(t *testing.T) {
+		t.Parallel()
+		var installedName string
+		r, cluster := newReconciler(t, func(_ context.Context, name string, _ *config.Config, _ []byte, _ int64) error {
+			installedName = name
+			return nil
+		})
+		cluster.Status.Addons[addons.StepTraefik] = k8znerv1alpha1.AddonStatus{
+			Installed:  true,
+			Phase:      k8znerv1alpha1.AddonPhaseFailed,
+			Version:    "38.0.0",
+			RetryCount: 3,
+		}
+
+		result, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+
+		assert.True(t, handled)
+		assert.Equal(t, addons.StepTraefik, installedName)
+		got := cluster.Status.Addons[addons.StepTraefik]
+		assert.Equal(t, k8znerv1alpha1.AddonPhaseInstalled, got.Phase)
+		assert.Equal(t, "39.0.0", got.Version)
+		assert.Zero(t, got.RetryCount)
+		assert.True(t, got.Installed)
+		assert.True(t, result.Requeue || result.RequeueAfter > 0)
+	})
+
+	t.Run("failed upgrade marks addon failed with backoff", func(t *testing.T) {
+		t.Parallel()
+		r, cluster := newReconciler(t, func(context.Context, string, *config.Config, []byte, int64) error {
+			return fmt.Errorf("chart render exploded")
+		})
+		cluster.Status.Addons[addons.StepTraefik] = k8znerv1alpha1.AddonStatus{
+			Installed: true,
+			Phase:     k8znerv1alpha1.AddonPhaseInstalled,
+			Version:   "38.0.0",
+		}
+
+		result, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+
+		assert.True(t, handled)
+		got := cluster.Status.Addons[addons.StepTraefik]
+		assert.Equal(t, k8znerv1alpha1.AddonPhaseFailed, got.Phase)
+		assert.Equal(t, "38.0.0", got.Version, "version must reflect what is actually running")
+		assert.Equal(t, 1, got.RetryCount)
+		assert.Contains(t, got.Message, "chart render exploded")
+		assert.Greater(t, result.RequeueAfter, time.Duration(0))
+	})
+
+	t.Run("nothing to do returns handled=false", func(t *testing.T) {
+		t.Parallel()
+		r, cluster := newReconciler(t, func(context.Context, string, *config.Config, []byte, int64) error {
+			t.Error("installer must not be called")
+			return nil
+		})
+		cluster.Status.Addons[addons.StepTraefik] = k8znerv1alpha1.AddonStatus{
+			Installed: true,
+			Phase:     k8znerv1alpha1.AddonPhaseInstalled,
+			Version:   "39.0.0",
+		}
+
+		_, handled := r.applyAddonPlan(context.Background(), cluster, steps, &config.Config{}, nil, 0)
+		assert.False(t, handled)
+	})
+}
+
+func TestAddonUpgradesGate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("upgrades only proceed when all nodes are ready", func(t *testing.T) {
+		t.Parallel()
+		cluster := &k8znerv1alpha1.K8znerCluster{
+			Status: k8znerv1alpha1.K8znerClusterStatus{
+				ControlPlanes: k8znerv1alpha1.NodeGroupStatus{Desired: 3, Ready: 2},
+				Workers:       k8znerv1alpha1.NodeGroupStatus{Desired: 2, Ready: 2},
+			},
+		}
+		assert.False(t, clusterStableForUpgrades(cluster))
+
+		cluster.Status.ControlPlanes.Ready = 3
+		assert.True(t, clusterStableForUpgrades(cluster))
+	})
+}

--- a/internal/operator/controller/reconcile_addons.go
+++ b/internal/operator/controller/reconcile_addons.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -20,6 +21,10 @@ import (
 	"github.com/milankappen/k8zner/internal/config"
 	operatorprov "github.com/milankappen/k8zner/internal/operator/provisioning"
 )
+
+// errCredentialsUnavailable marks failures loading the cluster credentials
+// so callers can report them under the CredentialsError event reason.
+var errCredentialsUnavailable = errors.New("failed to load credentials")
 
 // reconcileCNIPhase installs Cilium CNI as the first addon.
 // This must complete before any other pods can be scheduled (except hostNetwork pods).
@@ -189,7 +194,13 @@ func (r *ClusterReconciler) reconcileAddonsPhase(ctx context.Context, cluster *k
 
 	cfg, kubeconfig, networkID, err := r.prepareAddonInputs(ctx, cluster)
 	if err != nil {
-		r.logAndRecordError(ctx, cluster, err, EventReasonAddonsFailed, "Failed to prepare addon installation")
+		// Credential failures keep their dedicated reason so alerting that
+		// filters on CredentialsError sees them in every phase.
+		reason := EventReasonAddonsFailed
+		if errors.Is(err, errCredentialsUnavailable) {
+			reason = EventReasonCredentialsError
+		}
+		r.logAndRecordError(ctx, cluster, err, reason, "Failed to prepare addon installation")
 		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
 	}
 
@@ -218,7 +229,7 @@ func (r *ClusterReconciler) prepareAddonInputs(ctx context.Context, cluster *k8z
 func (r *ClusterReconciler) addonConfig(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster) (*config.Config, *operatorprov.Credentials, error) {
 	creds, err := r.phaseAdapter.LoadCredentials(ctx, cluster)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load credentials: %w", err)
+		return nil, nil, fmt.Errorf("%w: %w", errCredentialsUnavailable, err)
 	}
 
 	cfg, err := operatorprov.SpecToConfig(cluster, creds)

--- a/internal/operator/controller/reconcile_addons.go
+++ b/internal/operator/controller/reconcile_addons.go
@@ -110,6 +110,7 @@ func (r *ClusterReconciler) installAndWaitForCNI(ctx context.Context, cluster *k
 		Installed:          true,
 		Healthy:            true,
 		Phase:              k8znerv1alpha1.AddonPhaseInstalled,
+		Version:            addons.CNIVersion(cfg),
 		LastTransitionTime: &readyNow,
 		InstallOrder:       k8znerv1alpha1.AddonOrderCilium,
 		StartedAt:          &ciliumStart,
@@ -186,38 +187,44 @@ func (r *ClusterReconciler) reconcileAddonsPhase(ctx context.Context, cluster *k
 		return result, nil
 	}
 
-	creds, err := r.phaseAdapter.LoadCredentials(ctx, cluster)
+	cfg, kubeconfig, networkID, err := r.prepareAddonInputs(ctx, cluster)
 	if err != nil {
-		r.logAndRecordError(ctx, cluster, err, EventReasonCredentialsError, "Failed to load credentials")
-		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
-	}
-
-	cfg, err := operatorprov.SpecToConfig(cluster, creds)
-	if err != nil {
-		r.logAndRecordError(ctx, cluster, err, EventReasonAddonsFailed, "Failed to convert spec to config")
-		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
-	}
-	cfg.HCloudToken = creds.HCloudToken
-
-	kubeconfig, err := r.getKubeconfigFromTalos(ctx, cluster, creds)
-	if err != nil {
-		r.logAndRecordError(ctx, cluster, err, EventReasonAddonsFailed, "Failed to get kubeconfig")
-		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
-	}
-
-	networkID, err := r.resolveNetworkID(ctx, cluster)
-	if err != nil {
-		r.logAndRecordError(ctx, cluster, err, EventReasonAddonsFailed, "Failed to resolve network ID")
-		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
-	}
-
-	if cfg.HCloudToken == "" {
-		err := fmt.Errorf("HCloud token is empty")
-		r.logAndRecordError(ctx, cluster, err, EventReasonAddonsFailed, "CCM/CSI addons require valid credentials")
+		r.logAndRecordError(ctx, cluster, err, EventReasonAddonsFailed, "Failed to prepare addon installation")
 		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
 	}
 
 	return r.installNextAddon(ctx, cluster, cfg, kubeconfig, networkID)
+}
+
+// prepareAddonInputs assembles everything addon installation needs:
+// the expanded config (with credentials), a kubeconfig for the managed
+// cluster, and the HCloud network ID.
+func (r *ClusterReconciler) prepareAddonInputs(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster) (*config.Config, []byte, int64, error) {
+	creds, err := r.phaseAdapter.LoadCredentials(ctx, cluster)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to load credentials: %w", err)
+	}
+
+	cfg, err := operatorprov.SpecToConfig(cluster, creds)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to convert spec to config: %w", err)
+	}
+	cfg.HCloudToken = creds.HCloudToken
+	if cfg.HCloudToken == "" {
+		return nil, nil, 0, fmt.Errorf("HCloud token is empty")
+	}
+
+	kubeconfig, err := r.getKubeconfigFromTalos(ctx, cluster, creds)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	networkID, err := r.resolveNetworkID(ctx, cluster)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to resolve network ID: %w", err)
+	}
+
+	return cfg, kubeconfig, networkID, nil
 }
 
 // ensureWorkersReady checks if workers are ready, creating them if needed.
@@ -294,7 +301,7 @@ func (r *ClusterReconciler) installNextAddon(ctx context.Context, cluster *k8zne
 
 		installStart := metav1.Now()
 
-		if err := addons.InstallStep(ctx, step.Name, cfg, kubeconfig, networkID); err != nil {
+		if err := r.addonInstaller(ctx, step.Name, cfg, kubeconfig, networkID); err != nil {
 			r.logAndRecordError(ctx, cluster, err, EventReasonAddonsFailed,
 				fmt.Sprintf("Failed to install addon: %s", step.Name))
 			recordPhaseError(cluster, step.Name, err.Error())
@@ -326,6 +333,7 @@ func (r *ClusterReconciler) installNextAddon(ctx context.Context, cluster *k8zne
 			Installed:          true,
 			Healthy:            true,
 			Phase:              k8znerv1alpha1.AddonPhaseInstalled,
+			Version:            step.Version,
 			LastTransitionTime: &now,
 			InstallOrder:       step.Order,
 			StartedAt:          &installStart,

--- a/internal/operator/controller/reconcile_addons.go
+++ b/internal/operator/controller/reconcile_addons.go
@@ -200,31 +200,54 @@ func (r *ClusterReconciler) reconcileAddonsPhase(ctx context.Context, cluster *k
 // the expanded config (with credentials), a kubeconfig for the managed
 // cluster, and the HCloud network ID.
 func (r *ClusterReconciler) prepareAddonInputs(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster) (*config.Config, []byte, int64, error) {
+	cfg, creds, err := r.addonConfig(ctx, cluster)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	kubeconfig, networkID, err := r.addonClusterAccess(ctx, cluster, creds)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	return cfg, kubeconfig, networkID, nil
+}
+
+// addonConfig loads credentials and expands the CRD spec into the internal
+// config. Cheap: the secret read is served from the controller cache.
+func (r *ClusterReconciler) addonConfig(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster) (*config.Config, *operatorprov.Credentials, error) {
 	creds, err := r.phaseAdapter.LoadCredentials(ctx, cluster)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to load credentials: %w", err)
+		return nil, nil, fmt.Errorf("failed to load credentials: %w", err)
 	}
 
 	cfg, err := operatorprov.SpecToConfig(cluster, creds)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to convert spec to config: %w", err)
+		return nil, nil, fmt.Errorf("failed to convert spec to config: %w", err)
 	}
 	cfg.HCloudToken = creds.HCloudToken
 	if cfg.HCloudToken == "" {
-		return nil, nil, 0, fmt.Errorf("HCloud token is empty")
+		return nil, nil, fmt.Errorf("HCloud token is empty")
 	}
 
+	return cfg, creds, nil
+}
+
+// addonClusterAccess fetches what is needed to reach the managed cluster: a
+// kubeconfig (a Talos API round-trip) and the HCloud network ID. Expensive —
+// callers should establish there is work to do before calling it.
+func (r *ClusterReconciler) addonClusterAccess(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster, creds *operatorprov.Credentials) ([]byte, int64, error) {
 	kubeconfig, err := r.getKubeconfigFromTalos(ctx, cluster, creds)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to get kubeconfig: %w", err)
+		return nil, 0, fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
 
 	networkID, err := r.resolveNetworkID(ctx, cluster)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("failed to resolve network ID: %w", err)
+		return nil, 0, fmt.Errorf("failed to resolve network ID: %w", err)
 	}
 
-	return cfg, kubeconfig, networkID, nil
+	return kubeconfig, networkID, nil
 }
 
 // ensureWorkersReady checks if workers are ready, creating them if needed.

--- a/internal/operator/controller/reconcile_phases.go
+++ b/internal/operator/controller/reconcile_phases.go
@@ -321,6 +321,7 @@ func (r *ClusterReconciler) reconcileRunningPhase(ctx context.Context, cluster *
 	r.reconcileInfraHealth(ctx, cluster)
 	r.reconcileAddonHealth(ctx, cluster)
 	r.reconcileConnectivityHealth(ctx, cluster)
+	r.reconcileVersionSkew(ctx, cluster)
 
 	return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
 }

--- a/internal/operator/controller/reconcile_phases.go
+++ b/internal/operator/controller/reconcile_phases.go
@@ -309,6 +309,14 @@ func (r *ClusterReconciler) reconcileRunningPhase(ctx context.Context, cluster *
 		return result, err
 	}
 
+	// Non-fatal health probes: only run when cluster is stable (no scaling
+	// in progress). These run BEFORE addon upgrades so a persistently
+	// failing upgrade cannot starve health/version reporting forever.
+	r.reconcileInfraHealth(ctx, cluster)
+	r.reconcileAddonHealth(ctx, cluster)
+	r.reconcileConnectivityHealth(ctx, cluster)
+	r.reconcileVersionSkew(ctx, cluster)
+
 	// Keep addons converged on their desired versions (one upgrade per
 	// reconcile). Only operator-managed clusters carry credentials to do so.
 	if cluster.Spec.CredentialsRef.Name != "" {
@@ -316,12 +324,6 @@ func (r *ClusterReconciler) reconcileRunningPhase(ctx context.Context, cluster *
 			return result, nil
 		}
 	}
-
-	// Non-fatal health probes: only run when cluster is stable (no scaling in progress)
-	r.reconcileInfraHealth(ctx, cluster)
-	r.reconcileAddonHealth(ctx, cluster)
-	r.reconcileConnectivityHealth(ctx, cluster)
-	r.reconcileVersionSkew(ctx, cluster)
 
 	return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
 }

--- a/internal/operator/controller/reconcile_phases.go
+++ b/internal/operator/controller/reconcile_phases.go
@@ -309,6 +309,14 @@ func (r *ClusterReconciler) reconcileRunningPhase(ctx context.Context, cluster *
 		return result, err
 	}
 
+	// Keep addons converged on their desired versions (one upgrade per
+	// reconcile). Only operator-managed clusters carry credentials to do so.
+	if cluster.Spec.CredentialsRef.Name != "" {
+		if result, handled := r.reconcileAddonUpgrades(ctx, cluster); handled {
+			return result, nil
+		}
+	}
+
 	// Non-fatal health probes: only run when cluster is stable (no scaling in progress)
 	r.reconcileInfraHealth(ctx, cluster)
 	r.reconcileAddonHealth(ctx, cluster)

--- a/internal/operator/controller/reconcile_phases_test.go
+++ b/internal/operator/controller/reconcile_phases_test.go
@@ -611,10 +611,13 @@ func TestPhaseTransitionLogic(t *testing.T) {
 
 func TestReconcilePhases_EventRecording(t *testing.T) {
 	t.Parallel()
-	scheme := setupTestScheme(t)
 
 	t.Run("infrastructure skip records event", func(t *testing.T) {
 		t.Parallel()
+		// Per-subtest scheme: the fake client mutates its scheme when it
+		// Gets an unregistered type (connectivity probes), so parallel
+		// subtests must not share one.
+		scheme := setupTestScheme(t)
 		cluster := &k8znerv1alpha1.K8znerCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
@@ -652,6 +655,7 @@ func TestReconcilePhases_EventRecording(t *testing.T) {
 
 	t.Run("running phase records no error events when healthy", func(t *testing.T) {
 		t.Parallel()
+		scheme := setupTestScheme(t)
 		cluster := &k8znerv1alpha1.K8znerCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",

--- a/internal/operator/controller/reconcile_version_skew.go
+++ b/internal/operator/controller/reconcile_version_skew.go
@@ -13,6 +13,9 @@ import (
 	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
 )
 
+// EventReasonUpgradePending marks nodes lagging behind the spec version.
+const EventReasonUpgradePending = "UpgradePending"
+
 // reconcileVersionSkew surfaces pending Kubernetes upgrades as the UpToDate
 // condition by comparing each node's kubelet version against the spec. It is
 // detection only: node upgrades are rolled out explicitly via `k8zner apply`
@@ -57,6 +60,6 @@ func (r *ClusterReconciler) reconcileVersionSkew(ctx context.Context, cluster *k
 		Message: fmt.Sprintf("%d/%d nodes are not on Kubernetes %s; run `k8zner apply` to upgrade",
 			outdated, len(nodes.Items), desired),
 	})
-	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "UpgradePending",
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, EventReasonUpgradePending,
 		"%d/%d nodes need upgrading to Kubernetes %s", outdated, len(nodes.Items), desired)
 }

--- a/internal/operator/controller/reconcile_version_skew.go
+++ b/internal/operator/controller/reconcile_version_skew.go
@@ -1,0 +1,62 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
+)
+
+// reconcileVersionSkew surfaces pending Kubernetes upgrades as the UpToDate
+// condition by comparing each node's kubelet version against the spec. It is
+// detection only: node upgrades are rolled out explicitly via `k8zner apply`
+// (rebuilding the image and replacing nodes), never by the operator on its own.
+func (r *ClusterReconciler) reconcileVersionSkew(ctx context.Context, cluster *k8znerv1alpha1.K8znerCluster) {
+	desired := cluster.Spec.Kubernetes.Version
+	if desired == "" {
+		return
+	}
+
+	nodes := &corev1.NodeList{}
+	if err := r.List(ctx, nodes); err != nil {
+		log.FromContext(ctx).V(1).Info("skipping version skew check", "reason", err.Error())
+		return
+	}
+	if len(nodes.Items) == 0 {
+		return
+	}
+
+	outdated := 0
+	for _, node := range nodes.Items {
+		// Kubelet reports "v1.32.0"; the spec stores "1.32.0".
+		if strings.TrimPrefix(node.Status.NodeInfo.KubeletVersion, "v") != desired {
+			outdated++
+		}
+	}
+
+	if outdated == 0 {
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:    k8znerv1alpha1.ConditionUpToDate,
+			Status:  metav1.ConditionTrue,
+			Reason:  "VersionsMatch",
+			Message: fmt.Sprintf("All %d nodes run Kubernetes %s", len(nodes.Items), desired),
+		})
+		return
+	}
+
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:   k8znerv1alpha1.ConditionUpToDate,
+		Status: metav1.ConditionFalse,
+		Reason: "KubernetesUpgradePending",
+		Message: fmt.Sprintf("%d/%d nodes are not on Kubernetes %s; run `k8zner apply` to upgrade",
+			outdated, len(nodes.Items), desired),
+	})
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "UpgradePending",
+		"%d/%d nodes need upgrading to Kubernetes %s", outdated, len(nodes.Items), desired)
+}

--- a/internal/operator/controller/reconcile_version_skew_test.go
+++ b/internal/operator/controller/reconcile_version_skew_test.go
@@ -1,0 +1,92 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
+)
+
+func TestReconcileVersionSkew(t *testing.T) {
+	t.Parallel()
+
+	nodeWithKubelet := func(name, kubeletVersion string) *corev1.Node {
+		node := createTestNode(name, false, true)
+		node.Status.NodeInfo.KubeletVersion = kubeletVersion
+		return node
+	}
+
+	newCluster := func(specVersion string) *k8znerv1alpha1.K8znerCluster {
+		return &k8znerv1alpha1.K8znerCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+			Spec: k8znerv1alpha1.K8znerClusterSpec{
+				Kubernetes: k8znerv1alpha1.KubernetesSpec{Version: specVersion},
+			},
+		}
+	}
+
+	run := func(t *testing.T, cluster *k8znerv1alpha1.K8znerCluster, nodes ...*corev1.Node) {
+		t.Helper()
+		scheme := setupTestScheme(t)
+		builder := fake.NewClientBuilder().WithScheme(scheme)
+		for _, n := range nodes {
+			builder = builder.WithObjects(n)
+		}
+		r := NewClusterReconciler(builder.Build(), scheme, record.NewFakeRecorder(10),
+			WithHCloudClient(&MockHCloudClient{}))
+		r.reconcileVersionSkew(context.Background(), cluster)
+	}
+
+	t.Run("matching versions set UpToDate true", func(t *testing.T) {
+		t.Parallel()
+		cluster := newCluster("1.32.0")
+		run(t, cluster,
+			nodeWithKubelet("node-1", "v1.32.0"),
+			nodeWithKubelet("node-2", "v1.32.0"),
+		)
+
+		cond := meta.FindStatusCondition(cluster.Status.Conditions, k8znerv1alpha1.ConditionUpToDate)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	})
+
+	t.Run("outdated kubelet sets UpToDate false with node count", func(t *testing.T) {
+		t.Parallel()
+		cluster := newCluster("1.32.0")
+		run(t, cluster,
+			nodeWithKubelet("node-1", "v1.32.0"),
+			nodeWithKubelet("node-2", "v1.31.4"),
+		)
+
+		cond := meta.FindStatusCondition(cluster.Status.Conditions, k8znerv1alpha1.ConditionUpToDate)
+		require.NotNil(t, cond)
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		assert.Equal(t, "KubernetesUpgradePending", cond.Reason)
+		assert.Contains(t, cond.Message, "1/2")
+		assert.Contains(t, cond.Message, "1.32.0")
+	})
+
+	t.Run("no spec version means no condition", func(t *testing.T) {
+		t.Parallel()
+		cluster := newCluster("")
+		run(t, cluster, nodeWithKubelet("node-1", "v1.32.0"))
+
+		assert.Nil(t, meta.FindStatusCondition(cluster.Status.Conditions, k8znerv1alpha1.ConditionUpToDate))
+	})
+
+	t.Run("no nodes yet leaves condition untouched", func(t *testing.T) {
+		t.Parallel()
+		cluster := newCluster("1.32.0")
+		run(t, cluster)
+
+		assert.Nil(t, meta.FindStatusCondition(cluster.Status.Conditions, k8znerv1alpha1.ConditionUpToDate))
+	})
+}

--- a/internal/operator/crds/ensure.go
+++ b/internal/operator/crds/ensure.go
@@ -1,0 +1,49 @@
+// Package crds lets the operator self-manage its CustomResourceDefinitions.
+//
+// Helm never upgrades charts' crds/ directory, so operator deployments
+// installed or upgraded via Helm would otherwise keep serving the CRD schema
+// from their first install. The operator instead embeds its CRD (synced from
+// config/crd/bases via `make sync-crds`) and server-side-applies it at
+// startup, making the running operator the source of truth for the schema it
+// reconciles.
+package crds
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+//go:embed manifests/k8zner.io_k8znerclusters.yaml
+var clusterCRDManifest []byte
+
+// fieldOwner identifies the operator in managedFields for server-side apply.
+const fieldOwner = "k8zner-operator"
+
+// clusterCRD decodes the embedded K8znerCluster CRD manifest.
+func clusterCRD() (*apiextensionsv1.CustomResourceDefinition, error) {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := yaml.Unmarshal(clusterCRDManifest, crd); err != nil {
+		return nil, fmt.Errorf("failed to decode embedded CRD manifest: %w", err)
+	}
+	return crd, nil
+}
+
+// Ensure server-side-applies the operator's CRDs so the served schema always
+// matches the operator binary. ForceOwnership takes over fields previously
+// applied by kubectl or the CLI install path.
+func Ensure(ctx context.Context, c client.Client) error {
+	crd, err := clusterCRD()
+	if err != nil {
+		return err
+	}
+
+	if err := c.Patch(ctx, crd, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+		return fmt.Errorf("failed to apply CRD %s: %w", crd.Name, err)
+	}
+	return nil
+}

--- a/internal/operator/crds/ensure_test.go
+++ b/internal/operator/crds/ensure_test.go
@@ -1,0 +1,25 @@
+package crds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedCRD(t *testing.T) {
+	t.Parallel()
+
+	crd, err := clusterCRD()
+	require.NoError(t, err)
+
+	assert.Equal(t, "k8znerclusters.k8zner.io", crd.Name)
+	assert.Equal(t, "CustomResourceDefinition", crd.Kind)
+	assert.Equal(t, "apiextensions.k8s.io/v1", crd.APIVersion)
+	require.NotEmpty(t, crd.Spec.Versions)
+	assert.Equal(t, "v1alpha1", crd.Spec.Versions[0].Name)
+
+	// Server-side apply rejects objects carrying state from another cluster.
+	assert.Empty(t, crd.ResourceVersion)
+	assert.Empty(t, crd.UID)
+}

--- a/internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml
+++ b/internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml
@@ -94,6 +94,12 @@ spec:
                     default: true
                     description: Traefik ingress controller
                     type: boolean
+                  wildcardCertificate:
+                    description: |-
+                      WildcardCertificate additionally issues a "*.{domain}" certificate via
+                      DNS01 and sets it as Traefik's default certificate, so ingresses
+                      without an explicit TLS secret are covered. Requires domain.
+                    type: boolean
                 type: object
               backup:
                 description: Backup configures automated etcd backups

--- a/internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml
+++ b/internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml
@@ -82,6 +82,10 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
+                  logging:
+                    description: Logging enables the Loki + Alloy log aggregation
+                      stack
+                    type: boolean
                   metricsServer:
                     default: true
                     description: MetricsServer for resource metrics

--- a/internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml
+++ b/internal/operator/crds/manifests/k8zner.io_k8znerclusters.yaml
@@ -1,0 +1,816 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: k8znerclusters.k8zner.io
+spec:
+  group: k8zner.io
+  names:
+    kind: K8znerCluster
+    listKind: K8znerClusterList
+    plural: k8znerclusters
+    shortNames:
+    - k8z
+    singular: k8znercluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.controlPlanes.ready
+      name: CPs
+      type: string
+    - jsonPath: .status.workers.ready
+      name: Workers
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: K8znerCluster is the Schema for the k8znerclusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: K8znerClusterSpec defines the desired state of a K8zner-managed
+              cluster.
+            properties:
+              addons:
+                description: Addons specifies which addons should be installed
+                properties:
+                  argoSubdomain:
+                    description: |-
+                      ArgoSubdomain overrides the default "argo" subdomain for ArgoCD ingress.
+                      The full host will be "{argoSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
+                    type: string
+                  argocd:
+                    description: ArgoCD for GitOps
+                    type: boolean
+                  certManager:
+                    default: true
+                    description: CertManager for TLS certificates
+                    type: boolean
+                  externalDns:
+                    description: ExternalDNS for automatic DNS management
+                    type: boolean
+                  grafanaSubdomain:
+                    description: |-
+                      GrafanaSubdomain overrides the default "grafana" subdomain for Grafana ingress.
+                      The full host will be "{grafanaSubdomain}.{domain}".
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
+                    type: string
+                  metricsServer:
+                    default: true
+                    description: MetricsServer for resource metrics
+                    type: boolean
+                  monitoring:
+                    description: Monitoring enables kube-prometheus-stack (Prometheus,
+                      Grafana, Alertmanager)
+                    type: boolean
+                  traefik:
+                    default: true
+                    description: Traefik ingress controller
+                    type: boolean
+                type: object
+              backup:
+                description: Backup configures automated etcd backups
+                properties:
+                  enabled:
+                    description: Enabled turns on automated backups
+                    type: boolean
+                  retention:
+                    default: 168h
+                    description: 'Retention is how long to keep backups (default:
+                      168h = 7 days)'
+                    type: string
+                  s3SecretRef:
+                    description: |-
+                      S3SecretRef references a Secret containing S3 credentials for backup storage.
+                      The Secret must contain keys: access-key, secret-key, endpoint, bucket, region
+                      If not specified, backup will be skipped.
+                    properties:
+                      name:
+                        description: Name is the name of the Secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  schedule:
+                    default: 0 * * * *
+                    description: 'Schedule is the cron schedule for backups (default:
+                      hourly)'
+                    type: string
+                required:
+                - enabled
+                type: object
+              bootstrap:
+                description: Bootstrap contains the state from CLI bootstrap (if applicable)
+                properties:
+                  bootstrapNode:
+                    description: BootstrapNode is the name of the first control plane
+                      server
+                    type: string
+                  bootstrapNodeID:
+                    description: BootstrapNodeID is the Hetzner server ID of the first
+                      control plane
+                    format: int64
+                    type: integer
+                  completed:
+                    description: Completed indicates the CLI bootstrap has finished
+                    type: boolean
+                  completedAt:
+                    description: CompletedAt is when bootstrap completed
+                    format: date-time
+                    type: string
+                  publicIP:
+                    description: PublicIP is the public IP of the bootstrap node (before
+                      LB)
+                    type: string
+                required:
+                - completed
+                type: object
+              controlPlanes:
+                description: ControlPlanes defines the control plane configuration
+                properties:
+                  count:
+                    default: 1
+                    description: Count is the number of control plane nodes (1 for
+                      dev, 3 for HA)
+                    enum:
+                    - 1
+                    - 3
+                    - 5
+                    type: integer
+                  size:
+                    default: cx23
+                    description: |-
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
+                      CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
+                    type: string
+                required:
+                - count
+                - size
+                type: object
+              credentialsRef:
+                description: |-
+                  CredentialsRef references the Secret containing HCloud token and Talos secrets.
+                  Once set, it cannot be changed or removed: swapping credentials mid-lifecycle
+                  would silently re-point provisioning at a different Hetzner project.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: credentialsRef is immutable once set
+                  rule: '!has(oldSelf.name) || oldSelf.name == "" || (has(self.name)
+                    && self.name == oldSelf.name)'
+              domain:
+                description: |-
+                  Domain is the base domain for ingress resources (e.g., "example.com").
+                  When set, addons like ArgoCD and Grafana will have ingress automatically configured.
+                maxLength: 253
+                pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$
+                type: string
+              firewall:
+                description: Firewall configures the cluster firewall rules
+                properties:
+                  enabled:
+                    default: true
+                    description: Enabled determines if a firewall should be created
+                    type: boolean
+                type: object
+              healthCheck:
+                description: HealthCheck configures health monitoring thresholds
+                properties:
+                  etcdUnhealthyThreshold:
+                    default: 2m
+                    description: EtcdUnhealthyThreshold is how long etcd can be unhealthy
+                      before CP replacement
+                    type: string
+                  nodeNotReadyThreshold:
+                    default: 3m
+                    description: NodeNotReadyThreshold is how long a node can be NotReady
+                      before replacement
+                    type: string
+                type: object
+              kubernetes:
+                description: Kubernetes specifies the Kubernetes version
+                properties:
+                  version:
+                    description: Version is the Kubernetes version (e.g., "1.32.2")
+                    pattern: ^\d+\.\d+\.\d+$
+                    type: string
+                required:
+                - version
+                type: object
+              network:
+                description: Network configures the cluster networking
+                properties:
+                  ipv4CIDR:
+                    default: 10.0.0.0/16
+                    description: IPv4CIDR is the network CIDR for the Hetzner private
+                      network
+                    type: string
+                  nodeIPv4CIDR:
+                    description: |-
+                      NodeIPv4CIDR is the CIDR range for node IPs within the private network.
+                      This is used to calculate subnets for control planes, load balancers, and workers.
+                      If not set, defaults to "10.0.0.0/17" (lower half of the network CIDR).
+                    type: string
+                  podCIDR:
+                    default: 10.244.0.0/16
+                    description: PodCIDR is the CIDR range for pod IPs
+                    type: string
+                  serviceCIDR:
+                    default: 10.96.0.0/16
+                    description: ServiceCIDR is the CIDR range for service IPs
+                    type: string
+                type: object
+              paused:
+                description: Paused stops the operator from reconciling this cluster
+                type: boolean
+              placementGroup:
+                description: PlacementGroup configures server placement strategy
+                properties:
+                  enabled:
+                    default: true
+                    description: Enabled determines if a placement group should be
+                      created
+                    type: boolean
+                  type:
+                    default: spread
+                    description: Type is the placement group type (spread)
+                    enum:
+                    - spread
+                    type: string
+                type: object
+              region:
+                description: Region is the Hetzner Cloud region (e.g., fsn1, nbg1,
+                  hel1)
+                enum:
+                - fsn1
+                - nbg1
+                - hel1
+                type: string
+                x-kubernetes-validations:
+                - message: region is immutable
+                  rule: self == oldSelf
+              talos:
+                description: Talos specifies the Talos configuration
+                properties:
+                  extensions:
+                    description: Extensions is a list of Talos system extensions to
+                      include
+                    items:
+                      type: string
+                    type: array
+                  schematicID:
+                    description: SchematicID is the Talos Factory schematic ID for
+                      custom images
+                    type: string
+                  version:
+                    description: Version is the Talos version (e.g., "v1.10.2")
+                    pattern: ^v\d+\.\d+\.\d+$
+                    type: string
+                required:
+                - version
+                type: object
+              workers:
+                description: Workers defines the worker node configuration
+                properties:
+                  count:
+                    description: Count is the desired number of worker nodes
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  size:
+                    default: cx23
+                    description: |-
+                      Size is the Hetzner server type (e.g., cx23, cx33, cpx22, cpx32)
+                      CX types (dedicated vCPU) have consistent performance, CPX types (shared vCPU) have better availability
+                    type: string
+                required:
+                - count
+                - size
+                type: object
+            required:
+            - controlPlanes
+            - credentialsRef
+            - kubernetes
+            - region
+            - talos
+            - workers
+            type: object
+          status:
+            description: K8znerClusterStatus defines the observed state of K8znerCluster.
+            properties:
+              addons:
+                additionalProperties:
+                  description: AddonStatus represents the status of an installed addon.
+                  properties:
+                    duration:
+                      description: Duration is a human-readable duration of the installation
+                      type: string
+                    healthy:
+                      description: Healthy indicates if the addon is healthy
+                      type: boolean
+                    installOrder:
+                      description: InstallOrder is the order in which this addon should
+                        be installed
+                      type: integer
+                    installed:
+                      description: Installed indicates if the addon is installed
+                      type: boolean
+                    lastHealthCheck:
+                      description: LastHealthCheck is when the addon runtime health
+                        was last checked
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime is when the addon phase last
+                        changed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message provides additional status information
+                      type: string
+                    phase:
+                      description: Phase is the current installation phase of the
+                        addon
+                      enum:
+                      - Pending
+                      - Installing
+                      - Installed
+                      - Failed
+                      - Upgrading
+                      type: string
+                    retryCount:
+                      description: RetryCount tracks the number of installation retries
+                      type: integer
+                    startedAt:
+                      description: StartedAt is when the addon installation started
+                      format: date-time
+                      type: string
+                    version:
+                      description: Version is the installed version
+                      type: string
+                  required:
+                  - healthy
+                  - installed
+                  type: object
+                description: Addons shows the status of installed addons
+                type: object
+              conditions:
+                description: Conditions represent the latest available observations
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              connectivity:
+                description: Connectivity tracks external connectivity probe results
+                properties:
+                  endpoints:
+                    description: Endpoints is the health of external endpoints (ArgoCD,
+                      Grafana, etc.)
+                    items:
+                      description: EndpointHealth represents the health of a single
+                        external endpoint.
+                      properties:
+                        dnsReady:
+                          description: DNSReady indicates the DNS record resolves
+                          type: boolean
+                        host:
+                          description: Host is the FQDN of the endpoint
+                          type: string
+                        httpReady:
+                          description: HTTPReady indicates HTTPS returns a successful
+                            response
+                          type: boolean
+                        message:
+                          description: Message provides additional context
+                          type: string
+                        tlsReady:
+                          description: TLSReady indicates the TLS certificate exists
+                          type: boolean
+                      required:
+                      - dnsReady
+                      - host
+                      - httpReady
+                      - tlsReady
+                      type: object
+                    type: array
+                  kubeAPIReady:
+                    description: KubeAPIReady indicates the Kubernetes API is reachable
+                    type: boolean
+                  lastCheck:
+                    description: LastCheck is when connectivity was last checked
+                    format: date-time
+                    type: string
+                  metricsAPIReady:
+                    description: MetricsAPIReady indicates the metrics API is available
+                    type: boolean
+                required:
+                - kubeAPIReady
+                - metricsAPIReady
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint is the endpoint for the Kubernetes
+                  API
+                type: string
+              controlPlanes:
+                description: ControlPlanes shows the status of control plane nodes
+                properties:
+                  desired:
+                    description: Desired is the desired number of nodes
+                    type: integer
+                  nodes:
+                    description: Nodes is the detailed status of each node
+                    items:
+                      description: NodeStatus represents the status of a single node.
+                      properties:
+                        healthy:
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
+                          type: boolean
+                        lastHealthCheck:
+                          description: LastHealthCheck is when health was last checked
+                          format: date-time
+                          type: string
+                        name:
+                          description: Name is the Kubernetes node name
+                          type: string
+                        phase:
+                          description: Phase is the lifecycle phase of this node
+                          enum:
+                          - CreatingServer
+                          - WaitingForIP
+                          - WaitingForTalosAPI
+                          - ApplyingTalosConfig
+                          - RebootingWithConfig
+                          - WaitingForK8s
+                          - NodeInitializing
+                          - Ready
+                          - Unhealthy
+                          - Draining
+                          - RemovingFromEtcd
+                          - DeletingServer
+                          - Failed
+                          type: string
+                        phaseReason:
+                          description: PhaseReason provides additional context for
+                            the current phase
+                          type: string
+                        phaseTransitionTime:
+                          description: PhaseTransitionTime is when the node transitioned
+                            to the current phase
+                          format: date-time
+                          type: string
+                        privateIP:
+                          description: PrivateIP is the private network IP
+                          type: string
+                        publicIP:
+                          description: PublicIP is the public IP (if any)
+                          type: string
+                        serverID:
+                          description: ServerID is the Hetzner server ID
+                          format: int64
+                          type: integer
+                        unhealthyReason:
+                          description: UnhealthyReason explains why the node is unhealthy
+                          type: string
+                        unhealthySince:
+                          description: UnhealthySince is when the node became unhealthy
+                          format: date-time
+                          type: string
+                      required:
+                      - healthy
+                      - name
+                      - serverID
+                      type: object
+                    type: array
+                  ready:
+                    description: Ready is the number of healthy nodes
+                    type: integer
+                  unhealthy:
+                    description: Unhealthy is the number of unhealthy nodes
+                    type: integer
+                required:
+                - desired
+                - ready
+                type: object
+              imageSnapshot:
+                description: ImageSnapshot tracks the Talos image snapshot
+                properties:
+                  createdAt:
+                    description: CreatedAt is when the snapshot was created
+                    format: date-time
+                    type: string
+                  schematicID:
+                    description: SchematicID is the Talos Factory schematic ID
+                    type: string
+                  snapshotID:
+                    description: SnapshotID is the Hetzner snapshot ID
+                    format: int64
+                    type: integer
+                  version:
+                    description: Version is the Talos version of the snapshot
+                    type: string
+                type: object
+              infrastructure:
+                description: Infrastructure tracks the provisioned infrastructure
+                  resources
+                properties:
+                  firewallID:
+                    description: FirewallID is the Hetzner firewall ID
+                    format: int64
+                    type: integer
+                  firewallReady:
+                    description: FirewallReady indicates the firewall exists and is
+                      healthy
+                    type: boolean
+                  loadBalancerID:
+                    description: LoadBalancerID is the Hetzner load balancer ID
+                    format: int64
+                    type: integer
+                  loadBalancerIP:
+                    description: LoadBalancerIP is the public IP of the load balancer
+                    type: string
+                  loadBalancerPrivateIP:
+                    description: |-
+                      LoadBalancerPrivateIP is the private IP of the load balancer within the cluster network
+                      Used for internal cluster communication (preferred over public IP)
+                    type: string
+                  loadBalancerReady:
+                    description: LoadBalancerReady indicates the load balancer exists
+                      and has a public IP
+                    type: boolean
+                  networkID:
+                    description: NetworkID is the Hetzner network ID
+                    format: int64
+                    type: integer
+                  networkReady:
+                    description: NetworkReady indicates the network exists and is
+                      healthy
+                    type: boolean
+                  placementGroupID:
+                    description: PlacementGroupID is the Hetzner placement group ID
+                    format: int64
+                    type: integer
+                  snapshotID:
+                    description: SnapshotID is the Hetzner Talos image snapshot ID
+                    format: int64
+                    type: integer
+                  sshKeyID:
+                    description: SSHKeyID is the Hetzner SSH key ID used for nodes
+                    format: int64
+                    type: integer
+                type: object
+              lastErrors:
+                description: LastErrors is a ring buffer of recent errors (max 10).
+                items:
+                  description: ErrorRecord records a recent error for observability.
+                  properties:
+                    component:
+                      description: Component is the component that produced the error
+                      type: string
+                    message:
+                      description: Message is the error message
+                      type: string
+                    phase:
+                      description: Phase is the provisioning phase when the error
+                        occurred
+                      type: string
+                    time:
+                      description: Time is when the error occurred
+                      format: date-time
+                      type: string
+                  required:
+                  - message
+                  - time
+                  type: object
+                type: array
+              lastReconcileTime:
+                description: LastReconcileTime is when the operator last reconciled
+                  this cluster
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation
+                format: int64
+                type: integer
+              phase:
+                description: Phase is the overall cluster phase
+                enum:
+                - Provisioning
+                - Running
+                - Degraded
+                - Healing
+                - Failed
+                type: string
+              phaseHistory:
+                description: PhaseHistory records timing information for each provisioning
+                  phase.
+                items:
+                  description: PhaseRecord records timing information for a provisioning
+                    phase.
+                  properties:
+                    duration:
+                      description: Duration is a human-readable duration string
+                      type: string
+                    endedAt:
+                      description: EndedAt is when this phase completed
+                      format: date-time
+                      type: string
+                    error:
+                      description: Error is set if the phase encountered an error
+                      type: string
+                    phase:
+                      description: Phase is the provisioning phase
+                      type: string
+                    startedAt:
+                      description: StartedAt is when this phase started
+                      format: date-time
+                      type: string
+                  required:
+                  - phase
+                  - startedAt
+                  type: object
+                type: array
+              phaseStartedAt:
+                description: |-
+                  PhaseStartedAt tracks when the current provisioning phase started.
+                  Used for timeout detection in long-running phases like addon installation.
+                format: date-time
+                type: string
+              provisioningPhase:
+                description: ProvisioningPhase tracks the current provisioning stage
+                type: string
+              workers:
+                description: Workers shows the status of worker nodes
+                properties:
+                  desired:
+                    description: Desired is the desired number of nodes
+                    type: integer
+                  nodes:
+                    description: Nodes is the detailed status of each node
+                    items:
+                      description: NodeStatus represents the status of a single node.
+                      properties:
+                        healthy:
+                          description: Healthy indicates if the node is healthy (derived
+                            from Phase == NodePhaseReady)
+                          type: boolean
+                        lastHealthCheck:
+                          description: LastHealthCheck is when health was last checked
+                          format: date-time
+                          type: string
+                        name:
+                          description: Name is the Kubernetes node name
+                          type: string
+                        phase:
+                          description: Phase is the lifecycle phase of this node
+                          enum:
+                          - CreatingServer
+                          - WaitingForIP
+                          - WaitingForTalosAPI
+                          - ApplyingTalosConfig
+                          - RebootingWithConfig
+                          - WaitingForK8s
+                          - NodeInitializing
+                          - Ready
+                          - Unhealthy
+                          - Draining
+                          - RemovingFromEtcd
+                          - DeletingServer
+                          - Failed
+                          type: string
+                        phaseReason:
+                          description: PhaseReason provides additional context for
+                            the current phase
+                          type: string
+                        phaseTransitionTime:
+                          description: PhaseTransitionTime is when the node transitioned
+                            to the current phase
+                          format: date-time
+                          type: string
+                        privateIP:
+                          description: PrivateIP is the private network IP
+                          type: string
+                        publicIP:
+                          description: PublicIP is the public IP (if any)
+                          type: string
+                        serverID:
+                          description: ServerID is the Hetzner server ID
+                          format: int64
+                          type: integer
+                        unhealthyReason:
+                          description: UnhealthyReason explains why the node is unhealthy
+                          type: string
+                        unhealthySince:
+                          description: UnhealthySince is when the node became unhealthy
+                          format: date-time
+                          type: string
+                      required:
+                      - healthy
+                      - name
+                      - serverID
+                      type: object
+                    type: array
+                  ready:
+                    description: Ready is the number of healthy nodes
+                    type: integer
+                  unhealthy:
+                    description: Unhealthy is the number of unhealthy nodes
+                    type: integer
+                required:
+                - desired
+                - ready
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/internal/operator/provisioning/spec_converter.go
+++ b/internal/operator/provisioning/spec_converter.go
@@ -116,6 +116,10 @@ func buildAddonsConfig(spec *k8znerv1alpha1.K8znerClusterSpec) config.AddonsConf
 		ExternalDNS:         expandExternalDNSFromSpec(spec),
 		ArgoCD:              expandArgoCDFromSpec(spec),
 		KubePrometheusStack: expandMonitoringFromSpec(spec),
+		Logging: config.LoggingConfig{
+			Enabled:   spec.Addons != nil && spec.Addons.Logging,
+			Retention: "168h",
+		},
 	}
 }
 

--- a/internal/operator/provisioning/spec_converter.go
+++ b/internal/operator/provisioning/spec_converter.go
@@ -155,9 +155,10 @@ func configureCloudflare(cfg *config.Config, spec *k8znerv1alpha1.K8znerClusterS
 	// Enable CertManager Cloudflare integration for DNS-01 challenge
 	if cfg.Addons.CertManager.Enabled && spec.Domain != "" {
 		cfg.Addons.CertManager.Cloudflare = config.CertManagerCloudflareConfig{
-			Enabled:    true,
-			Production: true,
-			Email:      "admin@" + spec.Domain,
+			Enabled:             true,
+			Production:          true,
+			Email:               "admin@" + spec.Domain,
+			WildcardCertificate: spec.Addons != nil && spec.Addons.WildcardCertificate,
 		}
 	}
 }

--- a/internal/operator/provisioning/spec_converter.go
+++ b/internal/operator/provisioning/spec_converter.go
@@ -118,7 +118,7 @@ func buildAddonsConfig(spec *k8znerv1alpha1.K8znerClusterSpec) config.AddonsConf
 		KubePrometheusStack: expandMonitoringFromSpec(spec),
 		Logging: config.LoggingConfig{
 			Enabled:   spec.Addons != nil && spec.Addons.Logging,
-			Retention: "168h",
+			Retention: config.LoggingDefaultRetention,
 		},
 	}
 }

--- a/internal/operator/provisioning/spec_converter_test.go
+++ b/internal/operator/provisioning/spec_converter_test.go
@@ -1032,3 +1032,35 @@ func TestSpecToConfig_MinimalSpec(t *testing.T) {
 	// No cloudflare
 	assert.False(t, cfg.Addons.Cloudflare.Enabled)
 }
+
+func TestConfigureCloudflare_WildcardCertificate(t *testing.T) {
+	t.Parallel()
+
+	newCfg := func() *config.Config {
+		cfg := &config.Config{}
+		cfg.Addons.ExternalDNS.Enabled = true
+		cfg.Addons.CertManager.Enabled = true
+		return cfg
+	}
+
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Parallel()
+		cfg := newCfg()
+		spec := &k8znerv1alpha1.K8znerClusterSpec{Domain: "example.com"}
+
+		configureCloudflare(cfg, spec, baseCreds(), "test")
+		assert.False(t, cfg.Addons.CertManager.Cloudflare.WildcardCertificate)
+	})
+
+	t.Run("enabled from CRD spec", func(t *testing.T) {
+		t.Parallel()
+		cfg := newCfg()
+		spec := &k8znerv1alpha1.K8znerClusterSpec{
+			Domain: "example.com",
+			Addons: &k8znerv1alpha1.AddonSpec{WildcardCertificate: true},
+		}
+
+		configureCloudflare(cfg, spec, baseCreds(), "test")
+		assert.True(t, cfg.Addons.CertManager.Cloudflare.WildcardCertificate)
+	})
+}

--- a/internal/operator/provisioning/spec_converter_test.go
+++ b/internal/operator/provisioning/spec_converter_test.go
@@ -1064,3 +1064,35 @@ func TestConfigureCloudflare_WildcardCertificate(t *testing.T) {
 		assert.True(t, cfg.Addons.CertManager.Cloudflare.WildcardCertificate)
 	})
 }
+
+func TestSpecToConfig_Logging(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Parallel()
+		spec := &k8znerv1alpha1.K8znerClusterSpec{}
+		cluster := &k8znerv1alpha1.K8znerCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec:       *spec,
+		}
+
+		cfg, err := SpecToConfig(cluster, baseCreds())
+		require.NoError(t, err)
+		assert.False(t, cfg.Addons.Logging.Enabled)
+	})
+
+	t.Run("enabled from CRD spec with default retention", func(t *testing.T) {
+		t.Parallel()
+		cluster := &k8znerv1alpha1.K8znerCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: k8znerv1alpha1.K8znerClusterSpec{
+				Addons: &k8znerv1alpha1.AddonSpec{Logging: true},
+			},
+		}
+
+		cfg, err := SpecToConfig(cluster, baseCreds())
+		require.NoError(t, err)
+		assert.True(t, cfg.Addons.Logging.Enabled)
+		assert.Equal(t, "168h", cfg.Addons.Logging.Retention)
+	})
+}

--- a/internal/platform/cloudflare/client.go
+++ b/internal/platform/cloudflare/client.go
@@ -7,9 +7,14 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.cloudflare.com/client/v4"
+
+// requestTimeout bounds each Cloudflare API call so a degraded network
+// cannot hang DNS reconciliation indefinitely.
+const requestTimeout = 30 * time.Second
 
 // Client is a minimal Cloudflare API client for DNS record management.
 type Client struct {
@@ -56,7 +61,7 @@ type listResponse struct {
 func NewClient(apiToken string) *Client {
 	return &Client{
 		apiToken:   apiToken,
-		httpClient: &http.Client{},
+		httpClient: &http.Client{Timeout: requestTimeout},
 	}
 }
 

--- a/internal/platform/cloudflare/client_test.go
+++ b/internal/platform/cloudflare/client_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/milankappen/k8zner/internal/platform/dns"
 )
 
 func TestGetZoneID(t *testing.T) {
@@ -185,3 +187,6 @@ func split(s string, sep byte) []string {
 	result = append(result, s[start:])
 	return result
 }
+
+// Client must satisfy the provider-neutral DNS interface.
+var _ dns.Provider = (*Client)(nil)

--- a/internal/platform/dns/dns.go
+++ b/internal/platform/dns/dns.go
@@ -1,0 +1,19 @@
+// Package dns defines the provider-neutral interface for DNS backends.
+//
+// Cloudflare is the only implementation today; the interface exists so a
+// second provider (Hetzner DNS, Route53, ...) is an additive change for
+// consumers rather than surgery. Per repo convention it stays minimal: only
+// the methods consumers actually call belong here.
+package dns
+
+import "context"
+
+// Provider manages cluster-owned DNS records in a hosted zone.
+type Provider interface {
+	// GetZoneID resolves the hosted zone ID for a domain.
+	GetZoneID(ctx context.Context, domain string) (string, error)
+
+	// CleanupClusterRecords deletes all records owned by the given owner ID
+	// (external-dns TXT ownership) and returns how many were removed.
+	CleanupClusterRecords(ctx context.Context, zoneID, ownerID string) (int, error)
+}

--- a/internal/platform/hcloud/real_client.go
+++ b/internal/platform/hcloud/real_client.go
@@ -5,11 +5,18 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/milankappen/k8zner/internal/config"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
+
+// defaultHTTPTimeout bounds individual HTTP requests (Hetzner API calls and
+// public IP lookups) so a degraded network cannot hang provisioning or
+// reconciliation indefinitely. Long-running operations poll with many short
+// requests, so a per-request bound is safe.
+const defaultHTTPTimeout = 30 * time.Second
 
 // RealClient implements InfrastructureManager using the Hetzner Cloud API.
 type RealClient struct {
@@ -45,9 +52,12 @@ func WithHCloudClient(hc *hcloud.Client) ClientOption {
 // NewRealClient creates a new RealClient with optional configuration.
 func NewRealClient(token string, opts ...ClientOption) *RealClient {
 	c := &RealClient{
-		client:     hcloud.NewClient(hcloud.WithToken(token)),
+		client: hcloud.NewClient(
+			hcloud.WithToken(token),
+			hcloud.WithHTTPClient(&http.Client{Timeout: defaultHTTPTimeout}),
+		),
 		timeouts:   config.LoadTimeouts(),
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{Timeout: defaultHTTPTimeout},
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/internal/platform/hcloud/real_client_test.go
+++ b/internal/platform/hcloud/real_client_test.go
@@ -22,8 +22,8 @@ func TestNewRealClient_Defaults(t *testing.T) {
 	if client.httpClient == nil {
 		t.Error("expected httpClient to be initialized")
 	}
-	if client.httpClient != http.DefaultClient {
-		t.Error("expected httpClient to be http.DefaultClient by default")
+	if client.httpClient.Timeout != defaultHTTPTimeout {
+		t.Errorf("expected default httpClient timeout %v, got %v", defaultHTTPTimeout, client.httpClient.Timeout)
 	}
 }
 
@@ -93,8 +93,8 @@ func TestGetPublicIP_Success(t *testing.T) {
 	// refactoring to make the URL configurable.
 	_ = client
 
-	// Basic sanity check - the httpClient is used
-	if client.httpClient == http.DefaultClient {
+	// Basic sanity check - the injected client replaced the default
+	if client.httpClient != server.Client() {
 		t.Error("expected custom HTTP client to be used")
 	}
 }

--- a/internal/platform/talos/config_test.go
+++ b/internal/platform/talos/config_test.go
@@ -3,6 +3,7 @@ package talos
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -501,4 +502,28 @@ func TestLoadSecrets_Errors(t *testing.T) {
 
 func writeTestFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0600)
+}
+
+// TestGeneratedConfigEncryptsSecretsAtRest pins a security property we rely
+// on: Talos-generated control plane configs must carry a secretbox encryption
+// secret so Kubernetes Secrets are encrypted at rest in etcd. The machinery
+// includes it by default; this test ensures a future generator change or
+// machinery upgrade cannot silently drop it.
+func TestGeneratedConfigEncryptsSecretsAtRest(t *testing.T) {
+	t.Parallel()
+
+	sb, err := NewSecrets("v1.9.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGenerator("enc-check", "1.32.0", "v1.9.0", "https://1.2.3.4:6443", sb)
+	cfg, err := g.GenerateControlPlaneConfig([]string{"1.2.3.4"}, "cp-1", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(cfg), "secretboxEncryptionSecret") {
+		t.Error("control plane config lacks secretboxEncryptionSecret: Kubernetes Secrets would be stored unencrypted in etcd")
+	}
 }

--- a/internal/ui/tui/apply.go
+++ b/internal/ui/tui/apply.go
@@ -102,7 +102,7 @@ func pollCRDStatus(ctx context.Context, p *tea.Program, clusterName string, kube
 func fetchCRDStatus(ctx context.Context, k8sClient client.Client, clusterName string) (CRDStatusMsg, bool) {
 	cluster := &k8znerv1alpha1.K8znerCluster{}
 	key := client.ObjectKey{
-		Namespace: "k8zner-system",
+		Namespace: Namespace,
 		Name:      clusterName,
 	}
 

--- a/internal/ui/tui/crd_fetch_test.go
+++ b/internal/ui/tui/crd_fetch_test.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	k8znerv1alpha1 "github.com/milankappen/k8zner/api/v1alpha1"
+)
+
+func newTestCluster(namespace, name string, phase k8znerv1alpha1.ClusterPhase, provPhase k8znerv1alpha1.ProvisioningPhase) *k8znerv1alpha1.K8znerCluster {
+	return &k8znerv1alpha1.K8znerCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Status: k8znerv1alpha1.K8znerClusterStatus{
+			Phase:             phase,
+			ProvisioningPhase: provPhase,
+		},
+	}
+}
+
+func TestFetchCRDStatus_UsesConfiguredClusterName(t *testing.T) {
+	t.Parallel()
+
+	// Two clusters in the same namespace: the lookup must pick the configured
+	// one, not assume a single fixed name.
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(k8znerv1alpha1.Scheme).
+		WithObjects(
+			newTestCluster(Namespace, "cluster-a", k8znerv1alpha1.ClusterPhaseProvisioning, k8znerv1alpha1.PhaseCNI),
+			newTestCluster(Namespace, "cluster-b", k8znerv1alpha1.ClusterPhaseRunning, k8znerv1alpha1.PhaseComplete),
+		).
+		Build()
+
+	msg, done := fetchCRDStatus(context.Background(), k8sClient, "cluster-b")
+	assert.True(t, done)
+	assert.Equal(t, k8znerv1alpha1.ClusterPhaseRunning, msg.ClusterPhase)
+	assert.Equal(t, k8znerv1alpha1.PhaseComplete, msg.ProvPhase)
+
+	msg, done = fetchCRDStatus(context.Background(), k8sClient, "cluster-a")
+	assert.False(t, done)
+	assert.Equal(t, k8znerv1alpha1.ClusterPhaseProvisioning, msg.ClusterPhase)
+	assert.Equal(t, k8znerv1alpha1.PhaseCNI, msg.ProvPhase)
+}
+
+func TestFetchCRDStatus_NameNotFound(t *testing.T) {
+	t.Parallel()
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(k8znerv1alpha1.Scheme).
+		WithObjects(newTestCluster(Namespace, "cluster-a", k8znerv1alpha1.ClusterPhaseRunning, k8znerv1alpha1.PhaseComplete)).
+		Build()
+
+	msg, done := fetchCRDStatus(context.Background(), k8sClient, "no-such-cluster")
+	assert.False(t, done)
+	assert.Empty(t, msg.ClusterPhase)
+}
+
+func TestFetchCRDStatus_LooksUpInK8znerSystemNamespace(t *testing.T) {
+	t.Parallel()
+
+	// A cluster with the right name in the wrong namespace must not be found.
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(k8znerv1alpha1.Scheme).
+		WithObjects(newTestCluster("default", "my-cluster", k8znerv1alpha1.ClusterPhaseRunning, k8znerv1alpha1.PhaseComplete)).
+		Build()
+
+	msg, done := fetchCRDStatus(context.Background(), k8sClient, "my-cluster")
+	assert.False(t, done)
+	assert.Empty(t, msg.ClusterPhase)
+}
+
+func TestFetchDoctorStatus_UsesConfiguredClusterName(t *testing.T) {
+	t.Parallel()
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(k8znerv1alpha1.Scheme).
+		WithObjects(
+			newTestCluster(Namespace, "cluster-a", k8znerv1alpha1.ClusterPhaseProvisioning, k8znerv1alpha1.PhaseCNI),
+			newTestCluster(Namespace, "cluster-b", k8znerv1alpha1.ClusterPhaseRunning, k8znerv1alpha1.PhaseComplete),
+		).
+		Build()
+
+	msg, done := fetchDoctorStatus(context.Background(), k8sClient, "cluster-b")
+	require.False(t, msg.NotFound)
+	assert.True(t, done)
+	assert.Equal(t, k8znerv1alpha1.ClusterPhaseRunning, msg.ClusterPhase)
+}
+
+func TestFetchDoctorStatus_NameNotFound(t *testing.T) {
+	t.Parallel()
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(k8znerv1alpha1.Scheme).
+		WithObjects(newTestCluster(Namespace, "cluster-a", k8znerv1alpha1.ClusterPhaseRunning, k8znerv1alpha1.PhaseComplete)).
+		Build()
+
+	msg, done := fetchDoctorStatus(context.Background(), k8sClient, "no-such-cluster")
+	assert.True(t, msg.NotFound)
+	assert.False(t, done)
+}
+
+func TestFetchDoctorStatus_FetchError(t *testing.T) {
+	t.Parallel()
+
+	// A client whose scheme does not know K8znerCluster fails with a
+	// non-NotFound error, which must surface as FetchErr.
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(runtime.NewScheme()).
+		Build()
+
+	msg, done := fetchDoctorStatus(context.Background(), k8sClient, "cluster-a")
+	assert.False(t, done)
+	assert.False(t, msg.NotFound)
+	assert.NotEmpty(t, msg.FetchErr)
+}

--- a/internal/ui/tui/doctor.go
+++ b/internal/ui/tui/doctor.go
@@ -55,7 +55,7 @@ func RunDoctorTUI(ctx context.Context, k8sClient client.Client, clusterName stri
 func fetchDoctorStatus(ctx context.Context, k8sClient client.Client, clusterName string) (CRDStatusMsg, bool) {
 	cluster := &k8znerv1alpha1.K8znerCluster{}
 	key := client.ObjectKey{
-		Namespace: "k8zner-system",
+		Namespace: Namespace,
 		Name:      clusterName,
 	}
 

--- a/internal/ui/tui/model.go
+++ b/internal/ui/tui/model.go
@@ -10,6 +10,11 @@ import (
 	"github.com/milankappen/k8zner/internal/ui/benchmarks"
 )
 
+// Namespace is the Kubernetes namespace where k8zner resources live. It is
+// exported so the CLI layer can share the same definition without an import
+// cycle (the handlers package already imports this one).
+const Namespace = "k8zner-system"
+
 // BootstrapPhase represents a CLI bootstrap phase for display.
 type BootstrapPhase struct {
 	Name   string

--- a/tests/kind/operator_test.go
+++ b/tests/kind/operator_test.go
@@ -3,9 +3,9 @@
 package kind
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -24,181 +24,27 @@ func TestKindOperator(t *testing.T) {
 	})
 }
 
-// testOperatorCRDInstallation installs the K8znerCluster CRD.
+// testOperatorCRDInstallation installs the K8znerCluster CRD from the
+// canonical manifest in config/crd/bases so the test always exercises the
+// schema that ships with the operator.
 func testOperatorCRDInstallation(t *testing.T) {
 	if fw.IsInstalled("k8zner-crd") {
 		t.Log("Already installed, skipping")
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
+	crdManifest, err := os.ReadFile("../../config/crd/bases/k8zner.io_k8znerclusters.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read canonical CRD manifest: %v", err)
+	}
 
-	// Apply the CRD from the deploy directory
-	crdManifest := `---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: k8znerclusters.k8zner.io
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-spec:
-  group: k8zner.io
-  names:
-    kind: K8znerCluster
-    listKind: K8znerClusterList
-    plural: k8znerclusters
-    singular: k8znercluster
-    shortNames:
-      - k8z
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - name: Phase
-          type: string
-          jsonPath: .status.phase
-        - name: CPs
-          type: string
-          jsonPath: .status.controlPlanes.ready
-        - name: Workers
-          type: string
-          jsonPath: .status.workers.ready
-        - name: Age
-          type: date
-          jsonPath: .metadata.creationTimestamp
-      schema:
-        openAPIV3Schema:
-          type: object
-          description: K8znerCluster is the Schema for the k8znerclusters API.
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              description: K8znerClusterSpec defines the desired state of a K8zner-managed cluster.
-              required:
-                - region
-                - controlPlanes
-                - workers
-              properties:
-                region:
-                  type: string
-                  description: Region is the Hetzner Cloud region
-                  enum: [fsn1, nbg1, hel1, ash, hil]
-                controlPlanes:
-                  type: object
-                  description: ControlPlanes defines the control plane configuration
-                  required:
-                    - count
-                    - size
-                  properties:
-                    count:
-                      type: integer
-                      description: Number of control plane nodes
-                      enum: [1, 3, 5]
-                      default: 1
-                    size:
-                      type: string
-                      description: Hetzner server type
-                      default: cx23
-                workers:
-                  type: object
-                  description: Workers defines the worker node configuration
-                  required:
-                    - count
-                    - size
-                  properties:
-                    count:
-                      type: integer
-                      description: Desired number of worker nodes
-                      minimum: 1
-                      maximum: 100
-                    size:
-                      type: string
-                      description: Hetzner server type
-                      default: cx23
-                    minCount:
-                      type: integer
-                      description: Minimum number of workers
-                      minimum: 0
-                      default: 1
-                    maxCount:
-                      type: integer
-                      description: Maximum number of workers
-                      maximum: 100
-                      default: 10
-                paused:
-                  type: boolean
-                  description: Stops the operator from reconciling this cluster
-                  default: false
-            status:
-              type: object
-              description: K8znerClusterStatus defines the observed state of K8znerCluster.
-              properties:
-                phase:
-                  type: string
-                  description: Current phase of the cluster
-                  enum: [Pending, Provisioning, Running, Degraded, Healing, Failed]
-                controlPlanes:
-                  type: object
-                  properties:
-                    total:
-                      type: integer
-                    ready:
-                      type: integer
-                    unhealthy:
-                      type: integer
-                workers:
-                  type: object
-                  properties:
-                    total:
-                      type: integer
-                    ready:
-                      type: integer
-                    unhealthy:
-                      type: integer
-                conditions:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                      status:
-                        type: string
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      reason:
-                        type: string
-                      message:
-                        type: string
-                lastReconcileTime:
-                  type: string
-                  format: date-time
-                observedGeneration:
-                  type: integer
-                  format: int64
-`
-
-	fw.KubectlApply(t, crdManifest)
+	fw.KubectlApply(t, string(crdManifest))
 
 	// Wait for CRD to be established
 	fw.WaitForCRD(t, "k8znerclusters.k8zner.io", 30*time.Second)
 
 	fw.MarkInstalled("k8zner-crd")
 	t.Log("✓ K8znerCluster CRD installed")
-
-	_ = ctx // context for future use
 }
 
 // testOperatorCRDValidation tests that the CRD schema validation works.
@@ -212,6 +58,12 @@ metadata:
   namespace: default
 spec:
   region: invalid-region
+  credentialsRef:
+    name: test-credentials
+  kubernetes:
+    version: 1.34.1
+  talos:
+    version: v1.12.6
   controlPlanes:
     count: 1
     size: cx23
@@ -239,6 +91,12 @@ metadata:
   namespace: default
 spec:
   region: fsn1
+  credentialsRef:
+    name: test-credentials
+  kubernetes:
+    version: 1.34.1
+  talos:
+    version: v1.12.6
   controlPlanes:
     count: 2
     size: cx23
@@ -276,6 +134,12 @@ metadata:
   namespace: k8zner-test
 spec:
   region: fsn1
+  credentialsRef:
+    name: test-credentials
+  kubernetes:
+    version: 1.34.1
+  talos:
+    version: v1.12.6
   controlPlanes:
     count: 1
     size: cx23
@@ -306,13 +170,24 @@ spec:
 		t.Errorf("Expected region fsn1, got %v", spec["region"])
 	}
 
+	// Region and credentialsRef are guarded by CEL immutability rules.
+	if _, err := fw.Kubectl("patch", "k8znercluster", "-n", "k8zner-test", "test-cluster",
+		"--type=merge", "-p", `{"spec":{"region":"nbg1"}}`); err == nil {
+		t.Error("Expected region change to be rejected by CEL validation, but patch succeeded")
+	}
+
+	if _, err := fw.Kubectl("patch", "k8znercluster", "-n", "k8zner-test", "test-cluster",
+		"--type=merge", "-p", `{"spec":{"credentialsRef":{"name":"other-credentials"}}}`); err == nil {
+		t.Error("Expected credentialsRef change to be rejected by CEL validation, but patch succeeded")
+	}
+
 	t.Log("✓ K8znerCluster resource created successfully")
 }
 
 // testOperatorStatusSubresource tests that the status subresource works.
 func testOperatorStatusSubresource(t *testing.T) {
 	// Update status using kubectl patch
-	statusPatch := `{"status":{"phase":"Pending","controlPlanes":{"total":1,"ready":0,"unhealthy":0},"workers":{"total":2,"ready":0,"unhealthy":0}}}`
+	statusPatch := `{"status":{"phase":"Provisioning","controlPlanes":{"total":1,"ready":0,"unhealthy":0},"workers":{"total":2,"ready":0,"unhealthy":0}}}`
 
 	_, err := fw.Kubectl("patch", "k8znercluster", "-n", "k8zner-test", "test-cluster",
 		"--type=merge", "--subresource=status", "-p", statusPatch)
@@ -336,8 +211,8 @@ func testOperatorStatusSubresource(t *testing.T) {
 		t.Fatal("Cluster has no status after patch")
 	}
 
-	if status["phase"] != "Pending" {
-		t.Errorf("Expected phase Pending, got %v", status["phase"])
+	if status["phase"] != "Provisioning" {
+		t.Errorf("Expected phase Provisioning, got %v", status["phase"])
 	}
 
 	// Test status update to Running

--- a/tests/kind/self_healing_test.go
+++ b/tests/kind/self_healing_test.go
@@ -48,6 +48,12 @@ metadata:
   namespace: k8zner-selfhealing-test
 spec:
   region: fsn1
+  credentialsRef:
+    name: test-credentials
+  kubernetes:
+    version: 1.34.1
+  talos:
+    version: v1.12.6
   controlPlanes:
     count: 3
     size: cpx22
@@ -60,15 +66,15 @@ spec:
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Test phase transitions: Pending -> Running
-	t.Log("Testing phase transition: Pending -> Running")
-	pendingPatch := `{"status":{"phase":"Pending","controlPlanes":{"total":3,"ready":0,"unhealthy":0},"workers":{"total":2,"ready":0,"unhealthy":0}}}`
+	// Test phase transitions: Provisioning -> Running
+	t.Log("Testing phase transition: Provisioning -> Running")
+	pendingPatch := `{"status":{"phase":"Provisioning","controlPlanes":{"total":3,"ready":0,"unhealthy":0},"workers":{"total":2,"ready":0,"unhealthy":0}}}`
 	_, err := fw.Kubectl("patch", "k8znercluster", "-n", "k8zner-selfhealing-test", "self-healing-test",
 		"--type=merge", "--subresource=status", "-p", pendingPatch)
 	if err != nil {
-		t.Fatalf("Failed to patch status to Pending: %v", err)
+		t.Fatalf("Failed to patch status to Provisioning: %v", err)
 	}
-	verifyClusterPhase(t, "k8zner-selfhealing-test", "self-healing-test", "Pending")
+	verifyClusterPhase(t, "k8zner-selfhealing-test", "self-healing-test", "Provisioning")
 
 	// Transition to Running
 	runningPatch := `{"status":{"phase":"Running","controlPlanes":{"total":3,"ready":3,"unhealthy":0},"workers":{"total":2,"ready":2,"unhealthy":0}}}`
@@ -241,6 +247,12 @@ metadata:
   namespace: k8zner-selfhealing-test
 spec:
   region: nbg1
+  credentialsRef:
+    name: test-credentials
+  kubernetes:
+    version: 1.34.1
+  talos:
+    version: v1.12.6
   controlPlanes:
     count: 3
     size: cpx22


### PR DESCRIPTION
- Skip reconciliation for K8znerClusters marked for deletion so a
  deleting cluster is no longer provisioned or healed while the object
  disappears (infra tear-down stays an explicit action via destroy/cleanup)
- Enqueue actual K8znerCluster objects on node events instead of a
  hardcoded k8zner-system/cluster name, which never matched real
  clusters (CRDs are named after the cluster), so node events now
  actually trigger reconciliation
- Make status-update retry backoff context-aware instead of blocking
  with time.Sleep
- Add 30s per-request HTTP timeouts to the Hetzner and Cloudflare API
  clients so a degraded network cannot hang reconciliation indefinitely
- Trim whitespace from HCLOUD_TOKEN to tolerate secrets created with
  trailing newlines
- CI: enforce CRD/operator-chart sync (make check-crds /
  check-operator-chart) in the lint job; pin trivy-action to 0.35.0
  instead of @master
- Dockerfile: pin builder image to golang:1.26.3-alpine to match go.mod

https://claude.ai/code/session_014k7sosv91VoBBGAjeC7QQn